### PR TITLE
Use PHP 5.5 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,13 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm
   - nightly
 
-matrix:
-  allow_failures:
-    - php: nightly
-
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.4.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.5.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "description" : "Unittests for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^6.4.2",
-    "php" : ">=5.4.0"
+    "xp-framework/core": "^6.5.0",
+    "php" : ">=5.5.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/unittest/tests/AssertionsTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace unittest\tests;
  
+use lang\Object;
+use unittest\TestCase;
+use lang\Generic;
 use unittest\AssertionFailedError;
 use lang\types\Integer;
 use lang\types\ArrayList;
@@ -57,7 +60,7 @@ class AssertionsTest extends \unittest\TestCase {
 
   #[@test]
   public function equalsMethodIsInvoked() {
-    $instance= newinstance('lang.Object', [], '{
+    $instance= newinstance(Object::class, [], '{
       public $equalsInvoked= 0;
 
       public function equals($other) {
@@ -142,7 +145,7 @@ class AssertionsTest extends \unittest\TestCase {
 
   #[@test]
   public function thisIsAnInstanceOfTestCase() {
-    $this->assertInstanceOf('unittest.TestCase', $this);
+    $this->assertInstanceOf(TestCase::class, $this);
   }
 
   #[@test]
@@ -152,43 +155,43 @@ class AssertionsTest extends \unittest\TestCase {
 
   #[@test]
   public function thisIsAnInstanceOfObject() {
-    $this->assertInstanceOf('lang.Object', $this);
+    $this->assertInstanceOf(Object::class, $this);
   }    
 
   #[@test]
   public function objectIsAnInstanceOfObject() {
-    $this->assertInstanceOf('lang.Object', new \lang\Object());
+    $this->assertInstanceOf(Object::class, new \lang\Object());
   }    
 
   #[@test, @expect(AssertionFailedError::class)]
   public function objectIsNotAnInstanceOfString() {
-    $this->assertInstanceOf('lang.types.Integer', new \lang\Object());
+    $this->assertInstanceOf(Integer::class, new \lang\Object());
   }    
 
   #[@test, @expect(AssertionFailedError::class)]
   public function zeroIsNotAnInstanceOfGeneric() {
-    $this->assertInstanceOf('lang.Generic', 0);
+    $this->assertInstanceOf(Generic::class, 0);
   }    
 
   #[@test, @expect(AssertionFailedError::class)]
   public function nullIsNotAnInstanceOfGeneric() {
-    $this->assertInstanceOf('lang.Generic', null);
+    $this->assertInstanceOf(Generic::class, null);
   }    
 
   /** @deprecated */
   #[@test, @expect(AssertionFailedError::class)]
   public function xpNullIsNotAnInstanceOfGeneric() {
-    $this->assertInstanceOf('lang.Generic', \xp::null());
+    $this->assertInstanceOf(Generic::class, \xp::null());
   }    
 
   #[@test, @expect(AssertionFailedError::class)]
   public function thisIsNotAnInstanceOfString() {
-    $this->assertInstanceOf('lang.types.Integer', $this);
+    $this->assertInstanceOf(Integer::class, $this);
   }    
 
   #[@test]
   public function thisIsAnInstanceOfGeneric() {
-    $this->assertInstanceOf('lang.Generic', $this);
+    $this->assertInstanceOf(Generic::class, $this);
   }    
 
   #[@test]

--- a/src/test/php/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/unittest/tests/AssertionsTest.class.php
@@ -11,7 +11,7 @@ use net\xp_framework\unittest\Name;
 /**
  * Test assertion methods
  */
-class AssertionsTest extends \unittest\TestCase {
+class AssertionsTest extends TestCase {
 
   #[@test]
   public function trueIsTrue() {

--- a/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
+++ b/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace unittest\tests;
 
+use unittest\TestCase;
+use unittest\TestSkipped;
+use unittest\PrerequisitesNotMetError;
 use unittest\TestSuite;
 
 /**
@@ -27,7 +30,7 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
 
   #[@test]
   public function beforeClassMethodIsExecuted() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
       public static $initialized= false;
 
       #[@beforeClass]
@@ -44,7 +47,7 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
 
   #[@test]
   public function exceptionInBeforeClassSkipsTest() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
 
       #[@beforeClass]
       public static function prepareTestData() {
@@ -57,14 +60,14 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
       }
     }');
     $r= $this->suite->runTest($t)->outComeOf($t);
-    $this->assertInstanceOf('unittest.TestSkipped', $r);
-    $this->assertInstanceOf('unittest.PrerequisitesNotMetError', $r->reason);
+    $this->assertInstanceOf(TestSkipped::class, $r);
+    $this->assertInstanceOf(PrerequisitesNotMetError::class, $r->reason);
     $this->assertEquals('Exception in beforeClass method prepareTestData', $r->reason->getMessage());
   }
 
   #[@test]
   public function failedPrerequisiteInBeforeClassSkipsTest() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
 
       #[@beforeClass]
       public static function prepareTestData() {
@@ -77,14 +80,14 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
       }
     }');
     $r= $this->suite->runTest($t)->outComeOf($t);
-    $this->assertInstanceOf('unittest.TestSkipped', $r);
-    $this->assertInstanceOf('unittest.PrerequisitesNotMetError', $r->reason);
+    $this->assertInstanceOf(TestSkipped::class, $r);
+    $this->assertInstanceOf(PrerequisitesNotMetError::class, $r->reason);
     $this->assertEquals('Test data not available', $r->reason->getMessage());
   }
 
   #[@test]
   public function afterClassMethodIsExecuted() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
       public static $finalized= FALSE;
 
       #[@afterClass]
@@ -101,7 +104,7 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
 
   #[@test]
   public function allBeforeClassMethodsAreExecuted() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
       public static $initialized= [];
 
       #[@beforeClass]
@@ -123,7 +126,7 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
 
   #[@test]
   public function allAfterClassMethodsAreExecuted() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
       public static $finalized= [];
 
       #[@beforeClass]
@@ -145,7 +148,7 @@ abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
 
   #[@test]
   public function afterClassMethodIsNotExecutedWhenPrerequisitesFail() {
-    $t= newinstance('unittest.TestCase', ['fixture'], '{
+    $t= newinstance(TestCase::class, ['fixture'], '{
       public static $finalized= FALSE;
 
       #[@beforeClass]

--- a/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
+++ b/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
@@ -10,7 +10,7 @@ use unittest\TestSuite;
  *
  * @see   xp://unittest.TestSuite
  */
-abstract class BeforeAndAfterClassTest extends \unittest\TestCase {
+abstract class BeforeAndAfterClassTest extends TestCase {
   protected $suite= null;
     
   /**

--- a/src/test/php/unittest/tests/LimitTest.class.php
+++ b/src/test/php/unittest/tests/LimitTest.class.php
@@ -8,7 +8,7 @@ use unittest\TestSuite;
  *
  * @see    xp://unittest.TestSuite
  */
-class LimitTest extends \unittest\TestCase {
+class LimitTest extends TestCase {
   private $suite;
     
   /** @return void */

--- a/src/test/php/unittest/tests/LimitTest.class.php
+++ b/src/test/php/unittest/tests/LimitTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use unittest\TestCase;
 use unittest\TestSuite;
 
 /**
@@ -17,7 +18,7 @@ class LimitTest extends \unittest\TestCase {
 
   #[@test]
   public function timeouts() {
-    $r= $this->suite->runTest(newinstance('unittest.TestCase', ['fixture'], [
+    $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @limit(time= 0.010)] fixture' => function() {
         usleep(20 * 1000);
       }
@@ -27,7 +28,7 @@ class LimitTest extends \unittest\TestCase {
 
   #[@test]
   public function noTimeout() {
-    $r= $this->suite->runTest(newinstance('unittest.TestCase', ['fixture'], [
+    $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @limit(time= 0.010)] fixture' => function() {
         /* No timeout */
       }

--- a/src/test/php/unittest/tests/ListenerTest.class.php
+++ b/src/test/php/unittest/tests/ListenerTest.class.php
@@ -1,5 +1,12 @@
 <?php namespace unittest\tests;
 
+use unittest\TestExpectationMet;
+use unittest\TestResult;
+use unittest\TestAssertionFailed;
+use unittest\TestError;
+use unittest\TestWarning;
+use unittest\TestPrerequisitesNotMet;
+use unittest\TestNotRun;
 use unittest\TestCase;
 use unittest\TestSuite;
 use unittest\PrerequisitesNotMetError;
@@ -115,80 +122,80 @@ class ListenerTest extends TestCase implements \unittest\TestListener {
 
   #[@test]
   public function notifiedOnSuccess() {
-    $case= newinstance('unittest.TestCase', ['fixture'], [
+    $case= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
     ]);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
     $this->assertEquals($case, $this->invocations['testStarted'][0]);
-    $this->assertInstanceOf('unittest.TestExpectationMet', $this->invocations['testSucceeded'][0]);
+    $this->assertInstanceOf(TestExpectationMet::class, $this->invocations['testSucceeded'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
-    $this->assertInstanceOf('unittest.TestResult', $this->invocations['testRunFinished'][1]);
+    $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
   }    
 
   #[@test]
   public function notifiedOnFailure() {
-    $case= newinstance('unittest.TestCase', ['fixture'], [
+    $case= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(false); }
     ]);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
     $this->assertEquals($case, $this->invocations['testStarted'][0]);
-    $this->assertInstanceOf('unittest.TestAssertionFailed', $this->invocations['testFailed'][0]);
+    $this->assertInstanceOf(TestAssertionFailed::class, $this->invocations['testFailed'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
-    $this->assertInstanceOf('unittest.TestResult', $this->invocations['testRunFinished'][1]);
+    $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
   }    
 
   #[@test]
   public function notifiedOnException() {
-    $case= newinstance('unittest.TestCase', ['fixture'], [
+    $case= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { throw new IllegalArgumentException('Test'); }
     ]);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
     $this->assertEquals($case, $this->invocations['testStarted'][0]);
-    $this->assertInstanceOf('unittest.TestError', $this->invocations['testError'][0]);
+    $this->assertInstanceOf(TestError::class, $this->invocations['testError'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
-    $this->assertInstanceOf('unittest.TestResult', $this->invocations['testRunFinished'][1]);
+    $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
   }    
 
   #[@test]
   public function notifiedOnError() {
-    $case= newinstance('unittest.TestCase', ['fixture'], [
+    $case= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { trigger_error('Test error'); }
     ]);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
     $this->assertEquals($case, $this->invocations['testStarted'][0]);
-    $this->assertInstanceOf('unittest.TestWarning', $this->invocations['testWarning'][0]);
+    $this->assertInstanceOf(TestWarning::class, $this->invocations['testWarning'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
-    $this->assertInstanceOf('unittest.TestResult', $this->invocations['testRunFinished'][1]);
+    $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
   }    
 
   #[@test]
   public function notifiedOnSkipped() {
-    $case= newinstance('unittest.TestCase', ['fixture'], [
+    $case= newinstance(TestCase::class, ['fixture'], [
       'setUp' => function() { throw new PrerequisitesNotMetError('SKIP', null, $this->name); },
       '#[@test] fixture' => function() { /* Intentionally empty */ }
     ]);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
     $this->assertEquals($case, $this->invocations['testStarted'][0]);
-    $this->assertInstanceOf('unittest.TestPrerequisitesNotMet', $this->invocations['testSkipped'][0]);
+    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $this->invocations['testSkipped'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
-    $this->assertInstanceOf('unittest.TestResult', $this->invocations['testRunFinished'][1]);
+    $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
   }    
 
   #[@test]
   public function notifiedOnIgnored() {
-    $case= newinstance('unittest.TestCase', ['fixture'], [
+    $case= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @ignore] fixture' => function() { /* Intentionally empty */ }
     ]);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
     $this->assertEquals($case, $this->invocations['testStarted'][0]);
-    $this->assertInstanceOf('unittest.TestNotRun', $this->invocations['testNotRun'][0]);
+    $this->assertInstanceOf(TestNotRun::class, $this->invocations['testNotRun'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
-    $this->assertInstanceOf('unittest.TestResult', $this->invocations['testRunFinished'][1]);
+    $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
   }    
 }

--- a/src/test/php/unittest/tests/SpecialMethodsTest.class.php
+++ b/src/test/php/unittest/tests/SpecialMethodsTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use unittest\TestCase;
 use unittest\TestSuite;
 
 /**
@@ -23,7 +24,7 @@ class SpecialMethodsTest extends \unittest\TestCase {
    * @return  unittest.TestCase
    */
   protected function setUpCase() {
-    return newinstance('unittest.TestCase', ['setUp'], '{
+    return newinstance(TestCase::class, ['setUp'], '{
       #[@test]
       public function setUp() { }
     }');
@@ -31,7 +32,7 @@ class SpecialMethodsTest extends \unittest\TestCase {
 
   #[@test]
   public function stateUnchanged() {
-    $test= newinstance('unittest.TestCase', ['irrelevant'], '{
+    $test= newinstance(TestCase::class, ['irrelevant'], '{
       #[@test]
       public function irrelevant() { }
 
@@ -63,7 +64,7 @@ class SpecialMethodsTest extends \unittest\TestCase {
    * @return  unittest.TestCase
    */
   protected function tearDownCase() {
-    return newinstance('unittest.TestCase', ['tearDown'], '{
+    return newinstance(TestCase::class, ['tearDown'], '{
       #[@test]
       public function tearDown() { }
     }');
@@ -75,7 +76,7 @@ class SpecialMethodsTest extends \unittest\TestCase {
    * @return  unittest.TestCase
    */
   protected function getNameCase() {
-    return newinstance('unittest.TestCase', ['getName'], '{
+    return newinstance(TestCase::class, ['getName'], '{
       #[@test]
       public function getName($compound= FALSE) { }
     }');

--- a/src/test/php/unittest/tests/SpecialMethodsTest.class.php
+++ b/src/test/php/unittest/tests/SpecialMethodsTest.class.php
@@ -8,7 +8,7 @@ use unittest\TestSuite;
  *
  * @see      xp://unittest.TestSuite
  */
-class SpecialMethodsTest extends \unittest\TestCase {
+class SpecialMethodsTest extends TestCase {
   protected $suite= null;
     
   /**

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -18,7 +18,7 @@ use lang\ClassLoader;
  *
  * @see    xp://unittest.TestSuite
  */
-class SuiteTest extends \unittest\TestCase {
+class SuiteTest extends TestCase {
   private $suite;
     
   /** @return void */

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace unittest\tests;
 
+use unittest\TestCase;
+use unittest\TestResult;
+use unittest\TestPrerequisitesNotMet;
 use lang\Error;
 use lang\MethodNotImplementedException;
 use util\NoSuchElementException;
@@ -105,12 +108,12 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test, @expect(MethodNotImplementedException::class)]
   public function addInvalidTest() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['nonExistant'], '{}'));
+    $this->suite->addTest(newinstance(TestCase::class, ['nonExistant'], '{}'));
   }
 
   #[@test, @expect(MethodNotImplementedException::class)]
   public function runInvalidTest() {
-    $this->suite->runTest(newinstance('unittest.TestCase', ['nonExistant'], '{}'));
+    $this->suite->runTest(newinstance(TestCase::class, ['nonExistant'], '{}'));
   }
 
   #[@test]
@@ -130,8 +133,8 @@ class SuiteTest extends \unittest\TestCase {
     ]);
     $this->suite->addTestClass($class);
     $this->assertEquals(2, $this->suite->numTests());
-    $this->assertInstanceOf('unittest.TestCase', $this->suite->testAt(0));
-    $this->assertInstanceOf('unittest.TestCase', $this->suite->testAt(1));
+    $this->assertInstanceOf(TestCase::class, $this->suite->testAt(0));
+    $this->assertInstanceOf(TestCase::class, $this->suite->testAt(1));
   }
 
   #[@test]
@@ -178,10 +181,10 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function runningASingleSucceedingTest() {
-    $r= $this->suite->runTest(newinstance('unittest.TestCase', ['fixture'], [
+    $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
     ]));
-    $this->assertInstanceOf('unittest.TestResult', $r);
+    $this->assertInstanceOf(TestResult::class, $r);
     $this->assertEquals(1, $r->count(), 'count');
     $this->assertEquals(1, $r->runCount(), 'runCount');
     $this->assertEquals(1, $r->successCount(), 'successCount');
@@ -191,10 +194,10 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function runningASingleFailingTest() {
-    $r= $this->suite->runTest(newinstance('unittest.TestCase', ['fixture'], [
+    $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(false); }
     ]));
-    $this->assertInstanceOf('unittest.TestResult', $r);
+    $this->assertInstanceOf(TestResult::class, $r);
     $this->assertEquals(1, $r->count(), 'count');
     $this->assertEquals(1, $r->runCount(), 'runCount');
     $this->assertEquals(0, $r->successCount(), 'successCount');
@@ -204,21 +207,21 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function runMultipleTests() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(false); }
     ]));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
     ]));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       'setUp' => function() { throw new PrerequisitesNotMetError('Skip'); },
       '#[@test] fixture' => function() { $this->assertTrue(false); }
     ]));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @ignore] fixture' => function() { /* Empty */ }
     ]));
     $r= $this->suite->run();
-    $this->assertInstanceOf('unittest.TestResult', $r);
+    $this->assertInstanceOf(TestResult::class, $r);
     $this->assertEquals(4, $r->count(), 'count');
     $this->assertEquals(2, $r->runCount(), 'runCount');
     $this->assertEquals(1, $r->successCount(), 'successCount');
@@ -238,7 +241,7 @@ class SuiteTest extends \unittest\TestCase {
   public function runInvokesBeforeClassMultipleClasses() {
     $class= $this->classWithBeforeClass($this->name);
     $this->suite->addTest($class->newInstance('fixture'));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { /* Empty */ }
     ]));
     $this->suite->addTest($class->newInstance('fixture'));
@@ -255,7 +258,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function beforeClassRaisesAPrerequisitesNotMet() {
-    $t= newinstance('unittest.TestCase', ['irrelevant'], '{
+    $t= newinstance(TestCase::class, ['irrelevant'], '{
       #[@beforeClass]
       public static function raise() {
         throw new \unittest\PrerequisitesNotMetError("Cannot run");
@@ -269,14 +272,14 @@ class SuiteTest extends \unittest\TestCase {
     $this->suite->addTest($t);
     $r= $this->suite->run();
     $this->assertEquals(1, $r->skipCount(), 'skipCount');
-    $this->assertInstanceOf('unittest.TestPrerequisitesNotMet', $r->outcomeOf($t));
-    $this->assertInstanceOf('unittest.PrerequisitesNotMetError', $r->outcomeOf($t)->reason);
+    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $r->outcomeOf($t));
+    $this->assertInstanceOf(PrerequisitesNotMetError::class, $r->outcomeOf($t)->reason);
     $this->assertEquals('Cannot run', $r->outcomeOf($t)->reason->getMessage());
   }    
 
   #[@test]
   public function beforeClassRaisesAnException() {
-    $t= newinstance('unittest.TestCase', ['irrelevant'], '{
+    $t= newinstance(TestCase::class, ['irrelevant'], '{
       #[@beforeClass]
       public static function raise() {
         throw new \lang\IllegalStateException("Skip");
@@ -290,8 +293,8 @@ class SuiteTest extends \unittest\TestCase {
     $this->suite->addTest($t);
     $r= $this->suite->run();
     $this->assertEquals(1, $r->skipCount(), 'skipCount');
-    $this->assertInstanceOf('unittest.TestPrerequisitesNotMet', $r->outcomeOf($t));
-    $this->assertInstanceOf('unittest.PrerequisitesNotMetError', $r->outcomeOf($t)->reason);
+    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $r->outcomeOf($t));
+    $this->assertInstanceOf(PrerequisitesNotMetError::class, $r->outcomeOf($t)->reason);
     $this->assertEquals('Exception in beforeClass method raise', $r->outcomeOf($t)->reason->getMessage());
   }    
 
@@ -312,18 +315,18 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function warningsMakeTestFail() {
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { trigger_error('Test error'); }
     ]);
     $this->assertEquals(
-      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 316, occured once)'],
+      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 319, occured once)'],
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }
 
   #[@test]
   public function exceptionsMakeTestFail() {
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { throw new IllegalArgumentException('Test'); }
     ]);
     $this->assertInstanceOf(
@@ -334,24 +337,24 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function expectedExceptionsWithWarningsMakeTestFail() {
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect("lang.IllegalArgumentException")] fixture' => function() {
         trigger_error('Test error');
         throw new IllegalArgumentException('Test');
       }
     ]);
     $this->assertEquals(
-      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 339, occured once)'],
+      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 342, occured once)'],
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }
   
   #[@test]
   public function warningsDontAffectSucceedingTests() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { trigger_error('Test error'); }
     ]));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
     ]));
     $r= $this->suite->run();
@@ -361,10 +364,10 @@ class SuiteTest extends \unittest\TestCase {
  
   #[@test]
   public function warningsFromFailuresDontAffectSucceedingTests() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { trigger_error('Test error'); $this->assertTrue(false); }
     ]));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
     ]));
     $r= $this->suite->run();
@@ -374,11 +377,11 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function warningsFromSetupDontAffectSucceedingTests() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       'setUp' => function() { trigger_error('Error'); },
       '#[@test] fixture' => function() { /* Empty */ }
     ]));
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
     ]));
     $r= $this->suite->run();
@@ -387,7 +390,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function expectedException() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect("lang.IllegalArgumentException")] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
@@ -398,7 +401,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function subclassOfExpectedException() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect("lang.XPException")] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
@@ -409,7 +412,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function expectedExceptionNotThrown() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect("lang.IllegalArgumentException")] fixture' => function() {
         throw new FormatException('Test');
       }
@@ -424,7 +427,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function catchExpectedWithMessage() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "Test")] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
@@ -435,7 +438,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function catchExpectedWithMismatchingMessage() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "Hello")] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
@@ -450,7 +453,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function catchExpectedWithPatternMessage() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "/[tT]est/")] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
@@ -461,7 +464,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function catchExceptionsDuringSetUpOfTestDontBringDownTestSuite() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       'setUp' => function() { throw new IllegalArgumentException('In setup'); },
       'fixture' => function() { /* Intentionally empty */ }
     ]));
@@ -471,7 +474,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function doFail() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->fail('Test'); }
     ]));
     $r= $this->suite->run();
@@ -480,7 +483,7 @@ class SuiteTest extends \unittest\TestCase {
 
   #[@test]
   public function doSkip() {
-    $this->suite->addTest(newinstance('unittest.TestCase', ['fixture'], [
+    $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->skip('Test'); }
     ]));
     $r= $this->suite->run();

--- a/src/test/php/unittest/tests/TestActionTest.class.php
+++ b/src/test/php/unittest/tests/TestActionTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use unittest\TestPrerequisitesNotMet;
 use lang\ClassLoader;
 use lang\XPClass;
 use lang\IllegalStateException;
@@ -22,7 +23,7 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function beforeTest_and_afterTest_invocation_order() {
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       'run' => [],
       '#[@test, @action(new \unittest\tests\RecordActionInvocation("run"))] fixture' => function() {
         $this->run[]= 'test';
@@ -34,7 +35,7 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function beforeTest_is_invoked_before_setUp() {
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       'run' => [],
       'setUp' => function() {
         $this->run[]= 'setup';
@@ -49,7 +50,7 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function afterTest_is_invoked_after_tearDown() {
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       'run' => [],
       'tearDown' => function() {
         $this->run[]= 'teardown';
@@ -68,7 +69,7 @@ class TestActionTest extends TestCase {
       'beforeTest' => function(TestCase $t) { throw new PrerequisitesNotMetError('Skip'); },
       'afterTest' => function(TestCase $t) { /* NOOP */ }
     ]);
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @action(new \unittest\tests\SkipThisTest())] fixture' => function() {
         throw new IllegalStateException('This test should have been skipped');
       }
@@ -106,19 +107,19 @@ class TestActionTest extends TestCase {
         // NOOP
       }
     }');
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @action(new \unittest\tests\PlatformVerification("Test"))] fixture' => function() {
         throw new IllegalStateException('This test should have been skipped');
       }
     ]);
     $outcome= $this->suite->runTest($test)->outcomeOf($test);
-    $this->assertInstanceOf('unittest.TestPrerequisitesNotMet', $outcome);
+    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $outcome);
     $this->assertEquals(['Test'], $outcome->reason->prerequisites);
   }
 
   #[@test]
   public function multiple_actions() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $one= [], $two= [];
 
       #[@test, @action([
@@ -146,7 +147,7 @@ class TestActionTest extends TestCase {
         throw new \unittest\AssertionFailedError("Skip");
       }
     }');
-    $test= newinstance('unittest.TestCase', ['fixture'], [
+    $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @action(new \unittest\tests\FailOnTearDown())] fixture' => function() {
         // NOOP
       }
@@ -172,7 +173,7 @@ class TestActionTest extends TestCase {
         throw new \unittest\AssertionFailedError($this->message);
       }
     }');
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action([
       #  new \unittest\tests\FailOnTearDownWith("First"),
       #  new \unittest\tests\FailOnTearDownWith("Second")

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -11,7 +11,7 @@ use lang\ClassLoader;
  *
  * @see  xp://xp.unittest.Runner
  */
-class UnittestRunnerTest extends \unittest\TestCase {
+class UnittestRunnerTest extends TestCase {
   private $runner, $out, $err;
 
   /**

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use unittest\TestCase;
 use xp\unittest\Runner;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
@@ -100,7 +101,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runEmptyTest() {
-    $command= newinstance('unittest.TestCase', [$this->name]);
+    $command= newinstance(TestCase::class, [$this->name]);
     $return= $this->runner->run([nameof($command)]);
     $this->assertEquals(3, $return);
     $this->assertOnStream($this->err, '*** Warning: No tests found in');
@@ -117,7 +118,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runSucceedingTest() {
-    $command= newinstance('unittest.TestCase', ['succeeds'], [
+    $command= newinstance(TestCase::class, ['succeeds'], [
       '#[@test] succeeds' => function() { $this->assertTrue(true); }
     ]);
     $return= $this->runner->run([nameof($command)]);
@@ -128,7 +129,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runColoredTest($setting= '--color=on') {
-    $command= newinstance('unittest.TestCase', ['succeeds'], [
+    $command= newinstance(TestCase::class, ['succeeds'], [
       '#[@test] succeeds' => function() { $this->assertTrue(true); }
     ]);
     $return= $this->runner->run([$setting, nameof($command)]);
@@ -155,7 +156,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runUnsupportedColorSettingTestFails() {
-    $command= newinstance('unittest.TestCase', ['succeeds'], [
+    $command= newinstance(TestCase::class, ['succeeds'], [
       '#[@test] succeeds' => function() { $this->assertTrue(true); }
     ]);
     $return= $this->runner->run(['--color=anything', nameof($command)]);
@@ -165,7 +166,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runFailingTest() {
-    $command= newinstance('unittest.TestCase', ['fails'], [
+    $command= newinstance(TestCase::class, ['fails'], [
       '#[@test] fails' => function() { $this->assertTrue(false); }
     ]);
     $return= $this->runner->run([nameof($command)]);
@@ -205,7 +206,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runSingleTest() {
-    $command= newinstance('unittest.TestCase', ['succeeds'], [
+    $command= newinstance(TestCase::class, ['succeeds'], [
       '#[@test] succeeds' => function() { $this->assertTrue(true); }
     ]);
     $return= $this->runner->run([nameof($command).'::succeeds']);
@@ -215,7 +216,7 @@ class UnittestRunnerTest extends \unittest\TestCase {
 
   #[@test]
   public function runSingleTestWrongSpec() {
-    $command= newinstance('unittest.TestCase', ['succeeds'], [
+    $command= newinstance(TestCase::class, ['succeeds'], [
       '#[@test] succeeds' => function() { $this->assertTrue(true); }
     ]);
     $return= $this->runner->run([nameof($command).'::succeed']);

--- a/src/test/php/unittest/tests/ValuesTest.class.php
+++ b/src/test/php/unittest/tests/ValuesTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
  
+use unittest\TestCase;
 use lang\types\ArrayList;
 use unittest\TestSuite;
 
@@ -33,7 +34,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function inline_value_source() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       #[@test, @values([1, 2, 3])]
@@ -47,7 +48,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function local_value_source() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       public function values() {
@@ -65,7 +66,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function local_value_source_with_args() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       public function range($lo= 1, $hi= 3) {
@@ -83,7 +84,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function local_value_source_without_args() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       public function range($lo= 1, $hi= 3) {
@@ -101,7 +102,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function external_value_source_fully_qualified_class() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       #[@test, @values("unittest.tests.ValuesTest::range")]
@@ -115,7 +116,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function external_value_source_unqualified_class() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       #[@test, @values("unittest\\\\tests\\\\ValuesTest::range")]
@@ -129,7 +130,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function external_value_source_provider_and_args() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       #[@test, @values(source= "unittest.tests.ValuesTest::range", args= [1, 10])]
@@ -143,7 +144,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function local_value_source_with_self() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       public static function range() {
@@ -161,7 +162,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function all_variants_succeed() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       #[@test, @values([1, 2, 3])]
       public function fixture($value) {
         $this->assertTrue(TRUE);
@@ -173,7 +174,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function all_variants_fail() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       #[@test, @values([1, 2, 3])]
       public function fixture($value) {
         $this->assertTrue(FALSE);
@@ -185,7 +186,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function all_variants_skipped() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public function setUp() {
         throw new PrerequisitesNotMetError("Not ready yet");
       }
@@ -201,7 +202,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function some_variants_succeed_some_fail() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       #[@test, @values([1, 2, 3])]
       public function fixture($value) {
         $this->assertEquals(0, $value % 2);
@@ -214,7 +215,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function supplying_values_for_multiple_parameters() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       #[@test, @values([[1, 2], [3, 4], [5, 6]])]
@@ -229,7 +230,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function using_traversable_in_values() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       public function values() {
@@ -247,7 +248,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function using_this_in_value_provider() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       public function values() {
@@ -265,7 +266,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function protected_local_values_method() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       protected function values() {
@@ -283,7 +284,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function private_local_values_method() {
-    $test= newinstance('unittest.TestCase', ['fixture'], '{
+    $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
       private function values() {
@@ -301,7 +302,7 @@ class ValuesTest extends \unittest\TestCase {
 
   #[@test]
   public function values_with_expect() {
-    $test= newinstance('unittest.TestCase', ['not_at_number'], '{
+    $test= newinstance(TestCase::class, ['not_at_number'], '{
       #[@test, @values(["a"]), @expect("lang.FormatException")]
       public function not_at_number($value) {
         throw new \lang\FormatException("Not a number: ".$value);

--- a/src/test/php/unittest/tests/ValuesTest.class.php
+++ b/src/test/php/unittest/tests/ValuesTest.class.php
@@ -11,7 +11,7 @@ use unittest\TestSuite;
  * @see  https://github.com/xp-framework/xp-framework/issues/313
  * @see  https://github.com/xp-framework/xp-framework/issues/298
  */
-class ValuesTest extends \unittest\TestCase {
+class ValuesTest extends TestCase {
   protected $suite= null;
     
   /**

--- a/src/test/php/unittest/tests/VerifyThatTest.class.php
+++ b/src/test/php/unittest/tests/VerifyThatTest.class.php
@@ -8,7 +8,7 @@ use unittest\TestSuite;
 /**
  * Test VerifyThat class
  */
-class VerifyThatTest extends \unittest\TestCase {
+class VerifyThatTest extends TestCase {
   protected $suite= null;
 
   /**

--- a/src/test/php/unittest/tests/VerifyThatTest.class.php
+++ b/src/test/php/unittest/tests/VerifyThatTest.class.php
@@ -1,5 +1,8 @@
 <?php namespace unittest\tests;
 
+use unittest\TestExpectationMet;
+use unittest\TestPrerequisitesNotMet;
+use unittest\TestCase;
 use unittest\TestSuite;
 
 /**
@@ -23,7 +26,7 @@ class VerifyThatTest extends \unittest\TestCase {
    */
   protected function assertSucceeds($test) {
     $outcome= $this->suite->runTest($test)->outcomeOf($test);
-    $this->assertInstanceOf('unittest.TestExpectationMet', $outcome, \xp::stringOf($outcome));
+    $this->assertInstanceOf(TestExpectationMet::class, $outcome, \xp::stringOf($outcome));
   }
 
   /**
@@ -35,7 +38,7 @@ class VerifyThatTest extends \unittest\TestCase {
    */
   protected function assertSkipped($prerequisites, $test) {
     $outcome= $this->suite->runTest($test)->outcomeOf($test);
-    $this->assertInstanceOf('unittest.TestPrerequisitesNotMet', $outcome, \xp::stringOf($outcome));
+    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $outcome, \xp::stringOf($outcome));
     $this->assertEquals($prerequisites, $outcome->reason->prerequisites);
   }
 
@@ -50,7 +53,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_returning_true() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat(function() { return true; }))]
       public function fixture() { }
     }'));
@@ -58,7 +61,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_returning_false() {
-    $this->assertSkipped(['<function()>'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['<function()>'], newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat(function() { return false; }))]
       public function fixture() {
         throw new \lang\IllegalStateException("Should not be reached");
@@ -68,7 +71,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_throwing_exception() {
-    $this->assertSkipped(['<function()>'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['<function()>'], newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat(function() {
       #  throw new \lang\IllegalStateException("Test");
       #}))]
@@ -81,7 +84,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_accessing_member() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       public $member= true;
       #[@test, @action(new \unittest\actions\VerifyThat(function() { return $this->member; }))]
       public function fixture() { }
@@ -90,7 +93,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_accessing_protected_member() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       protected $member= true;
       #[@test, @action(new \unittest\actions\VerifyThat(function() { return $this->member; }))]
       public function fixture() { }
@@ -99,7 +102,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_accessing_static_member() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       public static $member= true;
       #[@test, @action(new \unittest\actions\VerifyThat(function() { return self::$member; }))]
       public function fixture() { }
@@ -108,7 +111,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_closure_accessing_protected_static_member() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       protected static $member= true;
       #[@test, @action(new \unittest\actions\VerifyThat(function() { return self::$member; }))]
       public function fixture() { }
@@ -117,7 +120,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_method_on_this_returning_true() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       public function returnTrue() { return true; }
 
       #[@test, @action(new \unittest\actions\VerifyThat("returnTrue"))]
@@ -127,7 +130,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_protected_method_on_this_returning_true() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       protected function returnTrue() { return true; }
 
       #[@test, @action(new \unittest\actions\VerifyThat("returnTrue"))]
@@ -137,7 +140,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_method_on_this_returning_false() {
-    $this->assertSkipped(['$this->returnFalse'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['$this->returnFalse'], newinstance(TestCase::class, ['fixture'], '{
       public function returnFalse() { return false; }
 
       #[@test, @action(new \unittest\actions\VerifyThat("returnFalse"))]
@@ -149,7 +152,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_static_method_on_self_returning_true() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       public static function returnTrue() { return true; }
 
       #[@test, @action(new \unittest\actions\VerifyThat("self::returnTrue"))]
@@ -159,7 +162,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_protected_static_method_on_self_returning_true() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       protected static function returnTrue() { return true; }
 
       #[@test, @action(new \unittest\actions\VerifyThat("self::returnTrue"))]
@@ -169,7 +172,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_static_method_on_this_returning_false() {
-    $this->assertSkipped(['self::returnFalse'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['self::returnFalse'], newinstance(TestCase::class, ['fixture'], '{
       public static function returnFalse() { return false; }
 
       #[@test, @action(new \unittest\actions\VerifyThat("self::returnFalse"))]
@@ -181,7 +184,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_static_method_on_other_class_returning_true() {
-    $this->assertSucceeds(newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSucceeds(newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat("unittest.tests.VerifyThatTest::returnTrue"))]
       public function fixture() { }
     }'));
@@ -189,7 +192,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_non_existant_method_on_this() {
-    $this->assertSkipped(['$this->non_existant_method'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['$this->non_existant_method'], newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat("non_existant_method"))]
       public function fixture() {
         throw new \lang\IllegalStateException("Should not be reached");
@@ -199,7 +202,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_non_existant_method_on_self() {
-    $this->assertSkipped(['self::non_existant_method'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['self::non_existant_method'], newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat("self::non_existant_method"))]
       public function fixture() {
         throw new \lang\IllegalStateException("Should not be reached");
@@ -209,7 +212,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_non_existant_method_on_class() {
-    $this->assertSkipped(['unittest.tests.VerifyThatTest::non_existant_method'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['unittest.tests.VerifyThatTest::non_existant_method'], newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat("unittest.tests.VerifyThatTest::non_existant_method"))]
       public function fixture() {
         throw new \lang\IllegalStateException("Should not be reached");
@@ -219,7 +222,7 @@ class VerifyThatTest extends \unittest\TestCase {
 
   #[@test]
   public function with_non_existant_class() {
-    $this->assertSkipped(['non.existant.Class::irrelevant'], newinstance('unittest.TestCase', ['fixture'], '{
+    $this->assertSkipped(['non.existant.Class::irrelevant'], newinstance(TestCase::class, ['fixture'], '{
       #[@test, @action(new \unittest\actions\VerifyThat("non.existant.Class::irrelevant"))]
       public function fixture() {
         throw new \lang\IllegalStateException("Should not be reached");

--- a/src/test/php/unittest/tests/XmlListenerTest.class.php
+++ b/src/test/php/unittest/tests/XmlListenerTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use xml\Node;
 use unittest\TestSuite;
 use unittest\PrerequisitesNotMetError;
 use unittest\XmlTestListener;
@@ -65,7 +66,7 @@ class XmlListenerTest extends \unittest\TestCase {
    * @throws  unittest.AssertionFailedError
    */
   protected function assertSuiteNode($name, $attr, $suite) {
-    $this->assertInstanceOf('xml.Node', $suite);
+    $this->assertInstanceOf(Node::class, $suite);
     $this->assertEquals('testsuite', $suite->getName());
     $this->assertEquals($name, $suite->getAttribute('name'));
     
@@ -82,7 +83,7 @@ class XmlListenerTest extends \unittest\TestCase {
    * @throws  unittest.AssertionFailedError
    */
   protected function assertCaseNode($attr, $suite) {
-    $this->assertInstanceOf('xml.Node', $suite);
+    $this->assertInstanceOf(Node::class, $suite);
     $this->assertEquals('testcase', $suite->getName());
     
     foreach ($attr as $key => $value) {
@@ -150,7 +151,7 @@ class XmlListenerTest extends \unittest\TestCase {
         $this->assertNotEquals(null, $case->getAttribute('time'));
 
         with ($failure= @$case->nodeAt(0)); {
-          $this->assertInstanceOf('xml.Node', $failure);
+          $this->assertInstanceOf(Node::class, $failure);
           $this->assertEquals('failure', $failure->getName());
           $this->assertNotEquals(null, $failure->getAttribute('message'));
           $this->assertNotEquals(null, $failure->getContent());
@@ -176,7 +177,7 @@ class XmlListenerTest extends \unittest\TestCase {
         $this->assertNotEquals(null, $case->getAttribute('time'));
 
         with ($failure= @$case->nodeAt(0)); {
-          $this->assertInstanceOf('xml.Node', $failure);
+          $this->assertInstanceOf(Node::class, $failure);
           $this->assertEquals('error', $failure->getName());
           $this->assertNotEquals(null, $failure->getAttribute('message'));
           $this->assertNotEquals(null, $failure->getContent());
@@ -202,7 +203,7 @@ class XmlListenerTest extends \unittest\TestCase {
         $this->assertNotEquals(null, $case->getAttribute('time'));
 
         with ($failure= @$case->nodeAt(0)); {
-          $this->assertInstanceOf('xml.Node', $failure);
+          $this->assertInstanceOf(Node::class, $failure);
           $this->assertEquals('error', $failure->getName());
           $this->assertNotEquals(null, $failure->getAttribute('message'));
           $this->assertNotEquals(null, $failure->getContent());


### PR DESCRIPTION
This pull request drops PHP 5.4 support by starting to rely on `T::class` and bumps the minimum PHP version required to 5.5. Converted using [this unperfect script](https://gist.github.com/thekid/d87c0db1f5902af26c4f) using PHP 5.5 mode

_Note: As the main source is not touched, unofficial PHP 5.4 support is still available though not tested with Travis-CI. This is consistent with [xp core 6.5.0](https://github.com/xp-framework/core/releases/tag/v6.5.0)._
