### PR TITLE
Refactor: Actions' before and after runlogic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,10 +3,7 @@ Unittests change log
 
 ## ?.?.? / ????-??-??
 
-* Changed *before* and *after* actions logic to run `afterTest()` only
-  for those actions which were successfully setup. Before, all actions
-  were run, resulting in more complex code inside actions to handle
-  cleanup correctly.
+* Merged pull request #6: Refactor: Actions' before and after runlogic
   (@thekid)
 * Changed `fail()` to also work without actual and expected parameters
   (@thekid)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,11 @@ Unittests change log
 
 ## ?.?.? / ????-??-??
 
+* Changed *before* and *after* actions logic to run `afterTest()` only
+  for those actions which were successfully setup. Before, all actions
+  were run, resulting in more complex code inside actions to handle
+  cleanup correctly.
+  (@thekid)
 * Changed `fail()` to also work without actual and expected parameters
   (@thekid)
 * Changed test case execution to catch PHP5 and PHP7 base exceptions

--- a/src/test/php/unittest/tests/RecordActionInvocation.class.php
+++ b/src/test/php/unittest/tests/RecordActionInvocation.class.php
@@ -5,7 +5,7 @@ use unittest\TestCase;
 /**
  * This class is used in the TestActionTest 
  */
-class RecordActionInvocation extends \lang\Object implements \unittest\TestAction {
+class RecordActionInvocation implements \unittest\TestAction {
   protected $field= null;
 
   /**

--- a/src/test/php/unittest/tests/RecordClassActionInvocation.class.php
+++ b/src/test/php/unittest/tests/RecordClassActionInvocation.class.php
@@ -5,7 +5,7 @@ use lang\XPClass;
 /**
  * This class is used in the TestClassActionTest 
  */
-class RecordClassActionInvocation extends \lang\Object implements \unittest\TestClassAction {
+class RecordClassActionInvocation implements \unittest\TestClassAction {
   protected $field= null;
 
   /**

--- a/src/test/php/unittest/tests/SkipThisTest.class.php
+++ b/src/test/php/unittest/tests/SkipThisTest.class.php
@@ -1,0 +1,29 @@
+<?php namespace unittest\tests;
+
+use unittest\TestCase;
+use unittest\PrerequisitesNotMetError;
+use lang\IllegalStateException;
+
+/**
+ * This class is used in the TestActionTest 
+ */
+class SkipThisTest extends \lang\Object implements \unittest\TestAction {
+
+  /**
+   * Before test: Update field
+   *
+   * @param  unittest.TestCase $t
+   */
+  public function beforeTest(TestCase $t) {
+    throw new PrerequisitesNotMetError('Skip');
+  }
+
+  /**
+   * After test: Update field
+   *
+   * @param  unittest.TestCase $t
+   */
+  public function afterTest(TestCase $t) {
+    throw new IllegalStateException('Should never be run!'); 
+  }
+}

--- a/src/test/php/unittest/tests/SkipThisTest.class.php
+++ b/src/test/php/unittest/tests/SkipThisTest.class.php
@@ -7,7 +7,7 @@ use lang\IllegalStateException;
 /**
  * This class is used in the TestActionTest 
  */
-class SkipThisTest extends \lang\Object implements \unittest\TestAction {
+class SkipThisTest implements \unittest\TestAction {
 
   /**
    * Before test: Update field


### PR DESCRIPTION
This pull request changes unittest actions' before and after runlogic to run `afterTest()` methods where the respective action's `beforeTest()` method completed sucessfully.

``` php
class AllocateResource implements \unittest\TestAction {
  private $resource;

  public function beforeTest(TestCase $t) {
    $this->resource= ...
  }

  public function afterTest(TestCase $t) {
    $this->resource->free();
  }
}

class Test extends \unittest\TestCase {

  #[@test, @action(new AllocateResource())]
  public function demo() {
    // ...
  }
}
```

When `Test::demo()` runs, the following happens:
1. The resource is allocated
2. The test is run
3. Regardless of the test's outcome, the resource is freed.

If allocating the resource fails for some reason and an exception is raised, the test is marked as errored due to this error. The `afterTest()` method is not called.

**So far, no change!**
## Change no. 1: Balanced before and after

If there are two or more actions though, the behavior is changed:

``` php
class Test extends \unittest\TestCase {

  #[@test, @action([new CreateTempDir(), new AllocateResource()])]
  public function demo() {
    // ...
  }
}
```

Now if allocating the resource fails, the `CreateTempDir::afterTest()` method will still be run _while previously, it would have not_.
## Change no. 2: Independence from setUp()

The second change introduced is that `after` methods will be invoked regardless of the setUp() method.

``` php
class Test extends \unittest\TestCase {

  public function setUp() {
    throw new ...
  }

  #[@test, @action([new AllocateResource()])]
  public function demo() {
    // ...
  }
}
```

Previously, if `setUp()` failed, the resource was allocated but never freed. This is fixed now.
