### PR TITLE
Wrap native exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Unittests for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^6.5.0",
+    "xp-framework/core": "^6.9",
     "xp-framework/io-collections": "^6.5.0",
     "php" : ">=5.5.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Unittests for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^6.9",
+    "xp-framework/core": "^6.9.1",
     "xp-framework/io-collections": "^6.5.0",
     "php" : ">=5.5.0"
   },

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -233,9 +233,9 @@ class TestSuite extends \lang\Object {
     } catch (Throwable $e) {
       throw $e;
     } catch (\Exception $e) {
-      throw new Error($e->getMessage());
+      throw Throwable::wrap($e);
     } catch (\Throwable $e) {
-      throw new Error($e->getMessage());
+      throw Throwable::wrap($e);
     }
   }
 

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -552,7 +552,7 @@ class SuiteTest extends TestCase {
     $this->assertEquals(1, $r->failureCount());
   }
 
-  #[@test, @values([IllegalArgumentException::class, 'Exception'])]
+  #[@test, @values([IllegalArgumentException::class, \Exception::class])]
   public function throwing_any_other_exception_from_setUp_fails_test($e) {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       'setUp' => function() use($e) { throw new $e('Fail'); },
@@ -572,7 +572,7 @@ class SuiteTest extends TestCase {
     $this->assertEquals(1, $r->failureCount());
   }
 
-  #[@test, @values([IllegalArgumentException::class, 'Exception'])]
+  #[@test, @values([IllegalArgumentException::class, \Exception::class])]
   public function throwing_any_other_exception_from_tearDown_fails_succeeding_test($e) {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       'tearDown' => function() use($e) { throw new $e('Fail'); },
@@ -582,7 +582,7 @@ class SuiteTest extends TestCase {
     $this->assertEquals(1, $r->failureCount());
   }
 
-  #[@test, @values([IllegalArgumentException::class, 'Exception'])]
+  #[@test, @values([IllegalArgumentException::class, \Exception::class])]
   public function throwing_any_other_exception_from_tearDown_fails_failing_test($e) {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
       'tearDown' => function() use($e) { throw new $e('Fail'); },

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -327,12 +327,34 @@ class SuiteTest extends TestCase {
   }
 
   #[@test]
-  public function exceptionsMakeTestFail() {
+  public function xp_exceptions_make_test_fail() {
     $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { throw new IllegalArgumentException('Test'); }
     ]);
     $this->assertInstanceOf(
       'lang.IllegalArgumentException',
+      $this->suite->runTest($test)->failed[$test->hashCode()]->reason
+    );
+  }
+
+  #[@test]
+  public function native_exceptions_make_test_fail() {
+    $test= newinstance(TestCase::class, ['fixture'], [
+      '#[@test] fixture' => function() { throw new \Exception('Test'); }
+    ]);
+    $this->assertInstanceOf(
+      'lang.Throwable',
+      $this->suite->runTest($test)->failed[$test->hashCode()]->reason
+    );
+  }
+
+  #[@test, @action(new RuntimeVersion('>=7.0.0'))]
+  public function native_php7_errors_make_test_fail() {
+    $test= newinstance(TestCase::class, ['fixture'], [
+      '#[@test] fixture' => function() { $null= null; $null->method(); }
+    ]);
+    $this->assertInstanceOf(
+      'lang.Error',
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }
@@ -346,7 +368,7 @@ class SuiteTest extends TestCase {
       }
     ]);
     $this->assertEquals(
-      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 344, occured once)'],
+      [sprintf('"Test error" in ::trigger_error() (SuiteTest.class.php, line %d, occured once)', __LINE__ - 5)],
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -343,7 +343,7 @@ class SuiteTest extends TestCase {
       '#[@test] fixture' => function() { throw new \Exception('Test'); }
     ]);
     $this->assertInstanceOf(
-      'lang.Throwable',
+      'lang.XPException',
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }


### PR DESCRIPTION
This pull request wraps native PHP 5 and PHP 7 exceptions inside a lang.Throwable and allows uniform access to stack trace, cause and message.

_Heads up: This bumps the XP Core requirement to 6.9.1_

/cc @patzerr
