### PR TITLE
Refactor sources

### DIFF
--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -6,6 +6,7 @@ use util\NoSuchElementException;
 
 class TestClass extends TestGroup {
   private $class, $arguments;
+  private $testMethods= [];
 
   static function __static() { }
 
@@ -23,7 +24,6 @@ class TestClass extends TestGroup {
       throw new IllegalArgumentException('Given argument is not a TestCase class ('.\xp::stringOf($class).')');
     }
 
-    $empty= true;
     foreach ($class->getMethods() as $method) {
       if ($method->hasAnnotation('test')) {
         if (self::$base->hasMethod($method->getName())) {
@@ -34,11 +34,11 @@ class TestClass extends TestGroup {
             $method->getDeclaringClass()->getName()
           ));
         }
-        $empty= false;
+        $this->testMethods[]= $method;
       }
     }
 
-    if ($empty) {
+    if (empty($this->testMethods)) {
       throw new NoSuchElementException('No tests found in '.$class->getName());
     }
 
@@ -48,13 +48,11 @@ class TestClass extends TestGroup {
 
   /** @return php.Generator */
   public function tests() {
-    foreach ($this->class->getMethods() as $method) {
-      if ($method->hasAnnotation('test')) {
-        yield $this->class->getConstructor()->newInstance(array_merge(
-          [$method->getName()],
-          (array)$this->arguments
-        ));
-      }
+    foreach ($this->testMethods as $method) {
+      yield $this->class->getConstructor()->newInstance(array_merge(
+        [$method->getName()],
+        (array)$this->arguments
+      ));
     }
   }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -34,7 +34,7 @@ class TestClass extends TestGroup {
             $method->getDeclaringClass()->getName()
           ));
         }
-        $this->testMethods[]= $method;
+        $this->testMethods[]= $method->getName();
       }
     }
 
@@ -52,9 +52,9 @@ class TestClass extends TestGroup {
   /** @return php.Generator */
   public function tests() {
     $constructor= $this->class->getConstructor();
-    foreach ($this->testMethods as $method) {
+    foreach ($this->testMethods as $name) {
       yield $constructor->newInstance(array_merge(
-        [$method->getName()],
+        [$name],
         (array)$this->arguments
       ));
     }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -46,6 +46,9 @@ class TestClass extends TestGroup {
     $this->arguments= $arguments;
   }
 
+  /** @return int */
+  public function numTests() { return sizeof($this->testMethods); }
+
   /** @return php.Generator */
   public function tests() {
     foreach ($this->testMethods as $method) {

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -51,8 +51,9 @@ class TestClass extends TestGroup {
 
   /** @return php.Generator */
   public function tests() {
+    $constructor= $this->class->getConstructor();
     foreach ($this->testMethods as $method) {
-      yield $this->class->getConstructor()->newInstance(array_merge(
+      yield $constructor->newInstance(array_merge(
         [$method->getName()],
         (array)$this->arguments
       ));

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -1,0 +1,58 @@
+<?php namespace unittest;
+
+use lang\IllegalStateException;
+use lang\XPClass;
+use util\NoSuchElementException;
+
+class TestClass {
+  private $class, $arguments;
+  private static $base;
+
+  static function __static() {
+    self::$base= new XPClass(TestCase::class);
+  }
+
+  /**
+   * Creates an instance from a testcase
+   *
+   * @param  lang.XPClass $class
+   * @param  var[] $args
+   * @throws lang.IllegalStateException
+   * @throws util.NoSuchElementException
+   */
+  public function __construct($class, $arguments) {
+    $empty= true;
+    foreach ($class->getMethods() as $method) {
+      if ($method->hasAnnotation('test')) {
+        if (self::$base->hasMethod($method->getName())) {
+          throw new IllegalStateException(sprintf(
+            'Cannot override %s::%s with test method in %s',
+            self::$base->getName(),
+            $method->getName(),
+            $method->getDeclaringClass()->getName()
+          ));
+        }
+        $empty= false;
+      }
+    }
+
+    if ($empty) {
+      throw new NoSuchElementException('No tests found in '.$class->getName());
+    }
+
+    $this->class= $class;
+    $this->arguments= $arguments;
+  }
+
+  /** @return php.Generator */
+  public function tests() {
+    foreach ($this->class->getMethods() as $method) {
+      if ($method->hasAnnotation('test')) {
+        yield $this->class->getConstructor()->newInstance(array_merge(
+          [$method->getName()],
+          (array)$this->arguments
+        ));
+      }
+    }
+  }
+}

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -14,9 +14,9 @@ class TestClass extends TestGroup {
    *
    * @param  lang.XPClass $class
    * @param  var[] $args
-   * @throws lang.IllegalArgumentException
-   * @throws lang.IllegalStateException
-   * @throws util.NoSuchElementException
+   * @throws lang.IllegalArgumentException in case given argument is not a testcase class
+   * @throws lang.IllegalStateException in case a test method is overridden
+   * @throws util.NoSuchElementException in case given testcase class does not contain any tests
    */
   public function __construct($class, $arguments) {
     if (!$class->isSubclassOf(self::$base)) {

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -1,6 +1,7 @@
 <?php namespace unittest;
 
 use lang\IllegalStateException;
+use lang\IllegalArgumentException;
 use util\NoSuchElementException;
 
 class TestClass extends TestGroup {
@@ -13,10 +14,15 @@ class TestClass extends TestGroup {
    *
    * @param  lang.XPClass $class
    * @param  var[] $args
+   * @throws lang.IllegalArgumentException
    * @throws lang.IllegalStateException
    * @throws util.NoSuchElementException
    */
   public function __construct($class, $arguments) {
+    if (!$class->isSubclassOf(self::$base)) {
+      throw new IllegalArgumentException('Given argument is not a TestCase class ('.\xp::stringOf($class).')');
+    }
+
     $empty= true;
     foreach ($class->getMethods() as $method) {
       if ($method->hasAnnotation('test')) {

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -1,6 +1,5 @@
 <?php namespace unittest;
 
-use lang\IllegalStateException;
 use lang\IllegalArgumentException;
 use util\NoSuchElementException;
 
@@ -26,15 +25,11 @@ class TestClass extends TestGroup {
 
     foreach ($class->getMethods() as $method) {
       if ($method->hasAnnotation('test')) {
-        if (self::$base->hasMethod($method->getName())) {
-          throw new IllegalStateException(sprintf(
-            'Cannot override %s::%s with test method in %s',
-            self::$base->getName(),
-            $method->getName(),
-            $method->getDeclaringClass()->getName()
-          ));
+        $name= $method->getName();
+        if (self::$base->hasMethod($name)) {
+          throw $this->cannotOverride($method);
         }
-        $this->testMethods[]= $method->getName();
+        $this->testMethods[]= $name;
       }
     }
 
@@ -43,7 +38,7 @@ class TestClass extends TestGroup {
     }
 
     $this->class= $class;
-    $this->arguments= $arguments;
+    $this->arguments= (array)$arguments;
   }
 
   /** @return int */
@@ -53,10 +48,7 @@ class TestClass extends TestGroup {
   public function tests() {
     $constructor= $this->class->getConstructor();
     foreach ($this->testMethods as $name) {
-      yield $constructor->newInstance(array_merge(
-        [$name],
-        (array)$this->arguments
-      ));
+      yield $constructor->newInstance(array_merge([$name], $this->arguments));
     }
   }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -1,16 +1,12 @@
 <?php namespace unittest;
 
 use lang\IllegalStateException;
-use lang\XPClass;
 use util\NoSuchElementException;
 
-class TestClass {
+class TestClass extends TestGroup {
   private $class, $arguments;
-  private static $base;
 
-  static function __static() {
-    self::$base= new XPClass(TestCase::class);
-  }
+  static function __static() { }
 
   /**
    * Creates an instance from a testcase

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -1,12 +1,28 @@
 <?php namespace unittest;
 
 use lang\XPClass;
+use lang\IllegalStateException;
 
 abstract class TestGroup {
   protected static $base;
 
   static function __static() {
     self::$base= new XPClass(TestCase::class);
+  }
+
+  /**
+   * Verify test method doesn't override a special method from TestCase
+   *
+   * @param  lang.reflect.Method $method
+   * @return lang.IllegalStateException
+   */
+  protected function cannotOverride($method) {
+    return new IllegalStateException(sprintf(
+      'Cannot override %s::%s with test method in %s',
+      self::$base->getName(),
+      $method->getName(),
+      $method->getDeclaringClass()->getName()
+    ));
   }
 
   /** @return int */

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -8,4 +8,10 @@ abstract class TestGroup {
   static function __static() {
     self::$base= new XPClass(TestCase::class);
   }
+
+  /** @return int */
+  public abstract function numTests();
+
+  /** @return php.Generator */
+  public abstract function tests();
 }

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -1,0 +1,11 @@
+<?php namespace unittest;
+
+use lang\XPClass;
+
+abstract class TestGroup {
+  protected static $base;
+
+  static function __static() {
+    self::$base= new XPClass(TestCase::class);
+  }
+}

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -12,8 +12,8 @@ class TestInstance extends TestGroup {
    * Creates an instance from a testcase
    *
    * @param  unittest.TestCase $instance
-   * @throws lang.MethodNotImplementedException
-   * @throws lang.IllegalStateException
+   * @throws lang.IllegalStateException for overriding test class methods with tests
+   * @throws lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function __construct($instance) {
     if (!$instance->getClass()->hasMethod($instance->name)) {

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -1,6 +1,5 @@
 <?php namespace unittest;
 
-use lang\IllegalStateException;
 use lang\MethodNotImplementedException;
 
 class TestInstance extends TestGroup {
@@ -16,17 +15,13 @@ class TestInstance extends TestGroup {
    * @throws lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function __construct($instance) {
-    if (!$instance->getClass()->hasMethod($instance->name)) {
+    $class= $instance->getClass();
+    if (!$class->hasMethod($instance->name)) {
       throw new MethodNotImplementedException('Test method does not exist', $instance->name);
     }
 
     if (self::$base->hasMethod($instance->name)) {
-      throw new IllegalStateException(sprintf(
-        'Cannot override %s::%s with test method in %s',
-        self::$base->getName(),
-        $instance->name,
-        nameof($instance)
-      ));
+      throw $this->cannotOverride($class->getMethod($instance->name));
     }
 
     $this->instance= $instance;

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -1,0 +1,37 @@
+<?php namespace unittest;
+
+use lang\IllegalStateException;
+use lang\XPClass;
+
+class TestInstance {
+  private $instance;
+  private static $base;
+
+  static function __static() {
+    self::$base= new XPClass(TestCase::class);
+  }
+
+  /**
+   * Creates an instance from a testcase
+   *
+   * @param  unittest.TestCase $instance
+   * @throws lang.IllegalStateException
+   */
+  public function __construct($instance) {
+    if (self::$base->hasMethod($instance->name)) {
+      throw new IllegalStateException(sprintf(
+        'Cannot override %s::%s with test method in %s',
+        self::$base->getName(),
+        $instance->name,
+        nameof($instance)
+      ));
+    }
+
+    $this->instance= $instance;
+  }
+
+  /** @return php.Generator */
+  public function tests() {
+    yield $this->instance;
+  }
+}

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -1,15 +1,11 @@
 <?php namespace unittest;
 
 use lang\IllegalStateException;
-use lang\XPClass;
 
-class TestInstance {
+class TestInstance extends TestGroup {
   private $instance;
-  private static $base;
 
-  static function __static() {
-    self::$base= new XPClass(TestCase::class);
-  }
+  static function __static() { }
 
   /**
    * Creates an instance from a testcase

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -32,6 +32,9 @@ class TestInstance extends TestGroup {
     $this->instance= $instance;
   }
 
+  /** @return int */
+  public function numTests() { return 1; }
+
   /** @return php.Generator */
   public function tests() {
     yield $this->instance;

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -1,6 +1,7 @@
 <?php namespace unittest;
 
 use lang\IllegalStateException;
+use lang\MethodNotImplementedException;
 
 class TestInstance extends TestGroup {
   private $instance;
@@ -11,9 +12,14 @@ class TestInstance extends TestGroup {
    * Creates an instance from a testcase
    *
    * @param  unittest.TestCase $instance
+   * @throws lang.MethodNotImplementedException
    * @throws lang.IllegalStateException
    */
   public function __construct($instance) {
+    if (!$instance->getClass()->hasMethod($instance->name)) {
+      throw new MethodNotImplementedException('Test method does not exist', $instance->name);
+    }
+
     if (self::$base->hasMethod($instance->name)) {
       throw new IllegalStateException(sprintf(
         'Cannot override %s::%s with test method in %s',

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -21,6 +21,7 @@ use lang\reflect\TargetInvocationException;
 class TestSuite extends \lang\Object {
   protected $listeners= [];
   private $sources= [];
+  private $numTests= 0;
 
   /**
    * Add a test
@@ -49,22 +50,20 @@ class TestSuite extends \lang\Object {
     $this->sources[$class->getName()][]= new TestClass($class, $arguments);
     return $class;
   }
-  
+
   /**
    * Returns number of tests in this suite
    *
    * @return  int
    */
   public function numTests() {
-    $num= 0;
+    $numTests= 0;
     foreach ($this->sources as $classname => $sources) {
       foreach ($sources as $source) {
-        foreach ($source->tests() as $test) {
-          $num++;
-        }
+        $numTests+= $source->numTests();
       }
     }
-    return $num;
+    return $numTests;
   }
   
   /**

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -41,7 +41,7 @@ class TestSuite extends \lang\Object {
    *
    * @param   lang.XPClass<unittest.TestCase> class
    * @param   var[] arguments default [] arguments to pass to test case constructor
-   * @return  lang.reflect.Method[] ignored test methods
+   * @return  lang.XPClass
    * @throws  lang.IllegalArgumentException in case given argument is not a testcase class
    * @throws  util.NoSuchElementException in case given testcase class does not contain any tests
    */

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -92,7 +92,22 @@ class TestSuite extends \lang\Object {
     }
     return null;
   }
-  
+
+  /**
+   * Returns all tests
+   *
+   * @return  php.Generator
+   */
+  public function tests() {
+    foreach ($this->sources as $classname => $groups) {
+      foreach ($groups as $group) {
+        foreach ($group->tests() as $test) {
+          yield $test;
+        }
+      }
+    }
+  }
+
   /**
    * Adds a listener
    *

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -20,12 +20,7 @@ use lang\reflect\TargetInvocationException;
  */
 class TestSuite extends \lang\Object {
   protected $listeners= [];
-  private static $base;
   private $sources= [];
-
-  static function __static() {
-    self::$base= new XPClass(TestCase::class);
-  }
 
   /**
    * Add a test
@@ -37,10 +32,6 @@ class TestSuite extends \lang\Object {
    * @throws  lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function addTest(TestCase $test) {
-    if (!$test->getClass()->hasMethod($test->name)) {
-      throw new MethodNotImplementedException('Test method does not exist', $test->name);
-    }
-
     $this->sources[nameof($test)][]= new TestInstance($test);
     return $test;
   }
@@ -55,10 +46,6 @@ class TestSuite extends \lang\Object {
    * @throws  util.NoSuchElementException in case given testcase class does not contain any tests
    */
   public function addTestClass($class, $arguments= []) {
-    if (!$class->isSubclassOf(self::$base)) {
-      throw new IllegalArgumentException('Given argument is not a TestCase class ('.\xp::stringOf($class).')');
-    }
-
     $this->sources[$class->getName()][]= new TestClass($class, $arguments);
     return $class;
   }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -33,7 +33,7 @@ class TestSuite extends \lang\Object {
    * @throws  lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function addTest(TestCase $test) {
-    $this->sources[nameof($test)][]= new TestInstance($test);
+    $this->sources[get_class($test)][]= new TestInstance($test);
     return $test;
   }
 
@@ -47,7 +47,7 @@ class TestSuite extends \lang\Object {
    * @throws  util.NoSuchElementException in case given testcase class does not contain any tests
    */
   public function addTestClass($class, $arguments= []) {
-    $this->sources[$class->getName()][]= new TestClass($class, $arguments);
+    $this->sources[$class->literal()][]= new TestClass($class, $arguments);
     return $class;
   }
 
@@ -484,7 +484,7 @@ class TestSuite extends \lang\Object {
 
     $result= new TestResult();
     foreach ($this->sources as $classname => $groups) {
-      $class= XPClass::forName($classname);
+      $class= new XPClass($classname);
 
       // Run all tests in this class
       try {

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -69,6 +69,7 @@ class TestSuite extends \lang\Object {
   /**
    * Remove all tests
    *
+   * @return void
    */
   public function clearTests() {
     $this->sources= [];
@@ -203,6 +204,7 @@ class TestSuite extends \lang\Object {
    *
    * @param   unittest.TestCase test
    * @param   unittest.TestResult result
+   * @return  void
    * @throws  lang.MethodNotImplementedException
    */
   protected function runInternal($test, $result) {
@@ -394,6 +396,7 @@ class TestSuite extends \lang\Object {
    *
    * @param   string method
    * @param   var[] args
+   * @return  void
    */
   protected function notifyListeners($method, $args) {
     foreach ($this->listeners as $l) {
@@ -407,6 +410,7 @@ class TestSuite extends \lang\Object {
    * other classes (if available)
    *
    * @param  lang.XPClass class
+   * @return void
    */
   protected function beforeClass($class) {
     foreach ($class->getMethods() as $m) {
@@ -432,6 +436,7 @@ class TestSuite extends \lang\Object {
    * exceptions thrown from these methods.
    *
    * @param  lang.XPClass class
+   * @return void
    */
   protected function afterClass($class) {
     foreach ($this->actionsFor($class, 'unittest.TestClassAction') as $action) {

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -58,9 +58,9 @@ class TestSuite extends \lang\Object {
    */
   public function numTests() {
     $numTests= 0;
-    foreach ($this->sources as $classname => $sources) {
-      foreach ($sources as $source) {
-        $numTests+= $source->numTests();
+    foreach ($this->sources as $classname => $groups) {
+      foreach ($groups as $group) {
+        $numTests+= $group->numTests();
       }
     }
     return $numTests;
@@ -82,9 +82,9 @@ class TestSuite extends \lang\Object {
    */
   public function testAt($pos) {
     $num= 0;
-    foreach ($this->sources as $classname => $sources) {
-      foreach ($sources as $source) {
-        foreach ($source->tests() as $test) {
+    foreach ($this->sources as $classname => $groups) {
+      foreach ($groups as $group) {
+        foreach ($group->tests() as $test) {
           if ($num++ === $pos) return $test;
         }
       }
@@ -483,23 +483,23 @@ class TestSuite extends \lang\Object {
     $this->notifyListeners('testRunStarted', [$this]);
 
     $result= new TestResult();
-    foreach ($this->sources as $classname => $sources) {
+    foreach ($this->sources as $classname => $groups) {
       $class= XPClass::forName($classname);
 
       // Run all tests in this class
       try {
         $this->beforeClass($class);
       } catch (PrerequisitesNotMetError $e) {
-        foreach ($sources as $source) {
-          foreach ($source->tests() as $test) {
+        foreach ($groups as $group) {
+          foreach ($group->tests() as $test) {
             $this->notifyListeners('testSkipped', [$result->setSkipped($test, $e, 0.0)]);
           }
         }
         continue;
       }
 
-      foreach ($sources as $source) {
-        foreach ($source->tests() as $test) {
+      foreach ($groups as $group) {
+        foreach ($group->tests() as $test) {
           $this->runInternal($test, $result);
         }
       }

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -182,6 +182,24 @@ class SuiteTest extends TestCase {
   }
 
   #[@test]
+  public function tests_initially_empty() {
+    $this->assertEquals([], iterator_to_array($this->suite->tests()));
+  }
+
+  #[@test]
+  public function tests_after_adding_one() {
+    $this->suite->addTest($this);
+    $this->assertEquals([$this], iterator_to_array($this->suite->tests()));
+  }
+
+  #[@test]
+  public function tests_after_adding_two() {
+    $this->suite->addTest($this);
+    $this->suite->addTest($this);
+    $this->assertEquals([$this, $this], iterator_to_array($this->suite->tests()));
+  }
+
+  #[@test]
   public function runningASingleSucceedingTest() {
     $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $this->assertTrue(true); }
@@ -321,7 +339,7 @@ class SuiteTest extends TestCase {
       '#[@test] fixture' => function() { trigger_error('Test error'); }
     ]);
     $this->assertEquals(
-      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 321, occured once)'],
+      [sprintf('"Test error" in ::trigger_error() (SuiteTest.class.php, line %d, occured once)', __LINE__ - 3)],
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }
@@ -346,7 +364,7 @@ class SuiteTest extends TestCase {
       }
     ]);
     $this->assertEquals(
-      ['"Test error" in ::trigger_error() (SuiteTest.class.php, line 344, occured once)'],
+      [sprintf('"Test error" in ::trigger_error() (SuiteTest.class.php, line %d, occured once)', __LINE__ - 5)],
       $this->suite->runTest($test)->failed[$test->hashCode()]->reason
     );
   }


### PR DESCRIPTION
## What's inside

This pull request:
- [x] Supersedes #8 (Refactor annotation handling) - where I could not solve increased memory usage
- [x] Is limited to extracting code creating test instances from classes from the TestSuite class
- [x] Can be built upon in future pull requests
- [x] Doesn't change performance and memory usage figures measurably
## Performance and memory figures

_Measured with PHP 7, figures for 5.6 and 5.5 different but also stable_

Baseline:

``` sh
Timm@slate ~/devel/xp/unittest [master]
$ unittest src/test/php/
#...
✓: 381/392 run (11 skipped), 381 succeeded, 0 failed
Memory used: 5047.26 kB (5107.70 kB peak)
Time taken: 0.100 seconds

Timm@slate ~/devel/xp/core [seven]
$ xp ... xp.unittest.Runner src/test/config/unittest/core.ini
# ...
✓: 2089/2118 run (29 skipped), 2089 succeeded, 0 failed
Memory used: 9708.79 kB (10500.16 kB peak)
Time taken: 1.300 seconds

Timm@slate ~/devel/xp/sequence [master]
$ xp ... xp.unittest.Runner src/test/php/
# ...

✓: 531/531 run (0 skipped), 531 succeeded, 0 failed
Memory used: 3312.18 kB (3615.58 kB peak)
Time taken: 0.047 seconds

```

After this code is merged:

``` sh
Timm@slate ~/devel/xp/unittest [refactor/sources]
$ unittest src/test/php/
# ...
✓: 384/395 run (11 skipped), 384 succeeded, 0 failed
Memory used: 5050.97 kB (5115.18 kB peak)
Time taken: 0.099 seconds

Timm@slate ~/devel/xp/core [seven]
$ xp ... xp.unittest.Runner src/test/config/unittest/core.ini
# ...
✓: 2089/2118 run (29 skipped), 2089 succeeded, 0 failed
Memory used: 9728.93 kB (10510.60 kB peak)
Time taken: 1.322 seconds

Timm@slate ~/devel/xp/sequence [master]
$ xp ... xp.unittest.Runner src/test/php/
# ...
✓: 531/531 run (0 skipped), 531 succeeded, 0 failed
Memory used: 3323.60 kB (3629.10 kB peak)
Time taken: 0.047 seconds
```
