### PR TITLE
Refactor: Provide test cases

### DIFF
--- a/src/main/php/xp/unittest/Runner.class.php
+++ b/src/main/php/xp/unittest/Runner.class.php
@@ -345,9 +345,13 @@ class Runner {
 
     foreach ($sources as $source) {
       try {
-        $tests= $source->testCasesWith($arguments);
-        foreach ($tests as $test) {
-          $suite->addTest($test);
+        if (method_exists($source, 'provideTo')) {
+          $source->provideTo($suite, $arguments);
+        } else {
+          $tests= $source->testCasesWith($arguments);
+          foreach ($tests as $test) {
+            $suite->addTest($test);
+          }
         }
       } catch (NoSuchElementException $e) {
         $this->err->writeLine('*** Warning: ', $e->getMessage());

--- a/src/main/php/xp/unittest/Runner.class.php
+++ b/src/main/php/xp/unittest/Runner.class.php
@@ -345,14 +345,7 @@ class Runner {
 
     foreach ($sources as $source) {
       try {
-        if (method_exists($source, 'provideTo')) {
-          $source->provideTo($suite, $arguments);
-        } else {
-          $tests= $source->testCasesWith($arguments);
-          foreach ($tests as $test) {
-            $suite->addTest($test);
-          }
-        }
+        $source->provideTo($suite, $arguments);
       } catch (NoSuchElementException $e) {
         $this->err->writeLine('*** Warning: ', $e->getMessage());
         continue;

--- a/src/main/php/xp/unittest/sources/AbstractSource.class.php
+++ b/src/main/php/xp/unittest/sources/AbstractSource.class.php
@@ -34,12 +34,4 @@ abstract class AbstractSource extends \lang\Object {
     }
     return $r;
   }
-
-  /**
-   * Get all test cases
-   *
-   * @param   var[] arguments
-   * @return  unittest.TestCase[]
-   */
-  public abstract function testCasesWith($arguments);
 }

--- a/src/main/php/xp/unittest/sources/AbstractSource.class.php
+++ b/src/main/php/xp/unittest/sources/AbstractSource.class.php
@@ -6,32 +6,11 @@
 abstract class AbstractSource extends \lang\Object {
 
   /**
-   * Get all test cases
+   * Provide tests to test suite
    *
-   * @param   lang.XPClass class
-   * @param   var[] arguments
-   * @return  unittest.TestCase[]
+   * @param  unittest.TestSuite $suite
+   * @param  var[] $arguments
+   * @return void
    */
-  public function testCasesInClass(\lang\XPClass $class, $arguments= null) {
-  
-    // Verify we were actually given a testcase class
-    if (!$class->isSubclassOf('unittest.TestCase')) {
-      throw new \lang\IllegalArgumentException('Given argument is not a TestCase class ('.\xp::stringOf($class).')');
-    }
-    
-    // Add all tests cases
-    $r= [];
-    foreach ($class->getMethods() as $m) {
-      $m->hasAnnotation('test') && $r[]= $class->getConstructor()->newInstance(array_merge(
-        (array)$m->getName(true), 
-        (array)$arguments
-      ));
-    }
-    
-    // Verify we actually added tests by doing this.
-    if (empty($r)) {
-      throw new \util\NoSuchElementException('No tests found in '.$class->getName());
-    }
-    return $r;
-  }
+  public abstract function provideTo($suite, $arguments);
 }

--- a/src/main/php/xp/unittest/sources/ClassSource.class.php
+++ b/src/main/php/xp/unittest/sources/ClassSource.class.php
@@ -1,46 +1,48 @@
 <?php namespace xp\unittest\sources;
 
+use lang\XPClass;
+
 /**
  * Source that load tests from a class filename
  */
 class ClassSource extends AbstractSource {
-  protected $testClass= null;
-  protected $method= null;
+  private $testClass, $method;
   
   /**
    * Constructor
    *
-   * @param   lang.XPClass testClass
-   * @param   string method default NULL
+   * @param  lang.XPClass $testClass
+   * @param  string $method
    */
-  public function __construct(\lang\XPClass $testClass, $method= null) {
+  public function __construct(XPClass $testClass, $method= null) {
     $this->testClass= $testClass;
     $this->method= $method;
   }
 
   /**
-   * Get all test cases
+   * Provide tests to test suite
    *
-   * @param   var[] arguments
-   * @return  unittest.TestCase[]
+   * @param  unittest.TestSuite $suite
+   * @param  var[] $arguments
+   * @return void
    */
-  public function testCasesWith($arguments) {
+  public function provideTo($suite, $arguments) {
     if (null === $this->method) {
-      return $this->testCasesInClass($this->testClass, $arguments);
+      return $suite->addTestClass($this->testClass, $arguments);
+    } else {
+      $suite->addTest($this->testClass->getConstructor()->newInstance(array_merge(
+        [$this->method],
+        (array)$arguments
+      )));
     }
-    
-    return [$this->testClass->getConstructor()->newInstance(array_merge(
-      (array)$this->method, 
-      (array)$arguments
-    ))];
   }
 
   /**
    * Creates a string representation of this source
    *
-   * @return  string
+   * @return string
    */
   public function toString() {
-    return nameof($this).'['.$this->testClass->toString().']';
+    return nameof($this).'['.$this->testClass->toString().($this->method ? '::'.$this->method : '').']';
   }
 }

--- a/src/main/php/xp/unittest/sources/EvaluationSource.class.php
+++ b/src/main/php/xp/unittest/sources/EvaluationSource.class.php
@@ -1,18 +1,19 @@
 <?php namespace xp\unittest\sources;
 
 use lang\ClassLoader;
+use unittest\TestCase;
 
 /**
  * Source that dynamically creates testcases
  */
 class EvaluationSource extends AbstractSource {
   private static $uniqId= 0;
-  private $testClass= null;
+  private $testClass;
   
   /**
    * Constructor
    *
-   * @param   string $src method sourcecode
+   * @param  string $src method sourcecode
    */
   public function __construct($src) {
 
@@ -22,27 +23,28 @@ class EvaluationSource extends AbstractSource {
       $src= substr($src, 6);
     }
 
-    $name= 'xp.unittest.DynamicallyGeneratedTestCase·'.(self::$uniqId++);
-    $this->testClass= ClassLoader::defineClass($name, 'unittest.TestCase', [], '{
+    $name= 'xp.unittest.DynamicallyGeneratedTestCase'.(self::$uniqId++);
+    $this->testClass= ClassLoader::defineClass($name, TestCase::class, [], '{
       #[@test] 
       public function run() { '.$src.' }
     }');
   }
 
   /**
-   * Get all test cases
+   * Provide tests to test suite
    *
-   * @param   var[] arguments
-   * @return  unittest.TestCase[]
+   * @param  unittest.TestSuite $suite
+   * @param  var[] $arguments
+   * @return void
    */
-  public function testCasesWith($arguments) {
-    return [$this->testClass->newInstance('run')];
+  public function provideTo($suite, $arguments) {
+    $suite->addTest($this->testClass->newInstance('run'));
   }
 
   /**
    * Creates a string representation of this source
    *
-   * @return  string
+   * @return string
    */
   public function toString() {
     return nameof($this).'['.$this->testClass->toString().']';

--- a/src/main/php/xp/unittest/sources/PackageSource.class.php
+++ b/src/main/php/xp/unittest/sources/PackageSource.class.php
@@ -13,8 +13,8 @@ class PackageSource extends AbstractSource {
   /**
    * Constructor
    *
-   * @param   lang.reflect.Package package
-   * @param   bool recursive default FALSE
+   * @param  lang.reflect.Package $package
+   * @param  bool $recursive
    */
   public function __construct(Package $package, $recursive= false) {
     $this->package= $package;
@@ -56,7 +56,7 @@ class PackageSource extends AbstractSource {
   /**
    * Creates a string representation of this source
    *
-   * @return  string
+   * @return string
    */
   public function toString() {
     return nameof($this).'['.$this->package->getName().($this->recursive ? '.**' : '.*').']';

--- a/src/main/php/xp/unittest/sources/PackageSource.class.php
+++ b/src/main/php/xp/unittest/sources/PackageSource.class.php
@@ -2,14 +2,13 @@
 
 use lang\reflect\Package;
 use lang\reflect\Modifiers;
+use unittest\TestCase;
 
 /**
  * Source that load tests from a package
  */
 class PackageSource extends AbstractSource {
-  protected
-    $package    = null,
-    $recursive  = false;
+  private $package, $recursive;
   
   /**
    * Constructor
@@ -21,43 +20,39 @@ class PackageSource extends AbstractSource {
     $this->package= $package;
     $this->recursive= $recursive;
   }
-  
+
   /**
-   * Returns a list of all classes inside a given package
+   * Provide tests from a given package to the test suite. Handles recursion.
    *
-   * @param   lang.reflect.Package 
-   * @param   bool recursive whether to include subpackages
-   * @return  lang.XPClass[]
+   * @param  lang.reflect.Package $package
+   * @param  unittest.TestSuite $suite
+   * @param  var[] $arguments
+   * @return void
    */
-  protected static function testClassesIn(Package $package, $recursive) {
-    $r= [];
+  private function provideFrom($package, $suite, $arguments) {
     foreach ($package->getClasses() as $class) {
-      if (
-        !$class->isSubclassOf('unittest.TestCase') ||
-        Modifiers::isAbstract($class->getModifiers())
-      ) continue;
-      $r[]= $class;
+      if ($class->isSubclassOf(TestCase::class) && !Modifiers::isAbstract($class->getModifiers())) {
+        $suite->addTestClass($class, $arguments);
+      }
     }
-    if ($recursive) foreach ($package->getPackages() as $package) {
-      $r= array_merge($r, self::testClassesIn($package, $recursive));
+    if ($this->recursive) {
+      foreach ($package->getPackages() as $package) {
+        $this->provideFrom($package, $suite, $arguments);
+      }
     }
-    return $r;
   }
 
   /**
-   * Get all test cases
+   * Provide tests to test suite
    *
-   * @param   var[] arguments
-   * @return  unittest.TestCase[]
+   * @param  unittest.TestSuite $suite
+   * @param  var[] $arguments
+   * @return void
    */
-  public function testCasesWith($arguments) {
-    $tests= [];
-    foreach (self::testClassesIn($this->package, $this->recursive) as $class) {
-      $tests= array_merge($tests, $this->testCasesInClass($class, $arguments));
-    }
-    return $tests;
+  public function provideTo($suite, $arguments) {
+    $this->provideFrom($this->package, $suite, $arguments);
   }
-  
+
   /**
    * Creates a string representation of this source
    *

--- a/src/main/php/xp/unittest/sources/PropertySource.class.php
+++ b/src/main/php/xp/unittest/sources/PropertySource.class.php
@@ -7,36 +7,35 @@ use lang\XPClass;
  * Source that load tests from a .ini file
  */
 class PropertySource extends AbstractSource {
-  protected $prop= null;
-  protected $descr= null;
+  private $properties, $description;
   
   /**
    * Constructor
    *
-   * @param   util.Properties prop
+   * @param  util.Properties $properties
    */
-  public function __construct(Properties $prop) {
-    $this->prop= $prop;
-    $this->descr= $this->prop->readString('this', 'description', 'Tests');
+  public function __construct(Properties $properties) {
+    $this->properties= $properties;
+    $this->description= $this->properties->readString('this', 'description', 'Tests');
   }
 
   /**
-   * Get all test cases
+   * Provide tests to test suite
    *
-   * @param   var[] arguments
-   * @return  unittest.TestCase[]
+   * @param  unittest.TestSuite $suite
+   * @param  var[] $arguments
+   * @return void
    */
-  public function testCasesWith($arguments) {
-    $r= [];
-    $section= $this->prop->getFirstSection();
+  public function provideTo($suite, $arguments) {
+    $section= $this->properties->getFirstSection();
     do {
-      if ('this' == $section) continue;   // Ignore special section
-      $r= array_merge($r, $this->testCasesInClass(
-        XPClass::forName($this->prop->readString($section, 'class')),
-        $arguments ? $arguments : $this->prop->readArray($section, 'args')
-      ));
-    } while ($section= $this->prop->getNextSection());
-    return $r;
+      if ('this' === $section) continue;   // Ignore special section
+
+      $suite->addTestClass(
+        XPClass::forName($this->properties->readString($section, 'class')),
+        $arguments ?: $this->properties->readArray($section, 'args')
+      );
+    } while ($section= $this->properties->getNextSection());
   }
 
   /**
@@ -45,6 +44,6 @@ class PropertySource extends AbstractSource {
    * @return  string
    */
   public function toString() {
-    return nameof($this).'['.$this->descr.' @ '.$this->prop->getFilename().']';
+    return nameof($this).'['.$this->description.' @ '.$this->properties->getFilename().']';
   }
 }

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -71,7 +71,7 @@ class UnittestRunnerTest extends TestCase {
   public function nonExistantFile() {
     $return= $this->runner->run(['@@NON-EXISTANT@@'.\xp::CLASS_FILE_EXT]);
     $this->assertEquals(2, $return);
-    $this->assertOnStream($this->err, '@@NON-EXISTANT@@.class.php" does not exist!');
+    $this->assertOnStream($this->err, '*** File "@@NON-EXISTANT@@.class.php" not found');
     $this->assertEquals('', $this->out->getBytes());
   }
 


### PR DESCRIPTION
Instead of having to return test instances, sources can now choose to add test classes to the test suite. This greatly simplifies the code inside source implementations and reduces code duplication.
## Performance / memory

Before

``` sh
Timm@slate ~/devel/xp/unittest [master]
$ unittest src/test/php/
# ...

✓: 378/389 run (11 skipped), 378 succeeded, 0 failed
Memory used: 4944.07 kB (5004.53 kB peak)
Time taken: 0.119 seconds

```

After

``` sh
$ unittest src/test/php/
# ...

✓: 378/389 run (11 skipped), 378 succeeded, 0 failed
Memory used: 4923.72 kB (4984.18 kB peak)
Time taken: 0.109 seconds
```
