### PR TITLE
Add "stop after first failing test" option

### DIFF
--- a/src/main/php/unittest/IgnoredBecause.class.php
+++ b/src/main/php/unittest/IgnoredBecause.class.php
@@ -1,0 +1,25 @@
+<?php namespace unittest;
+
+/**
+ * Indicates an `@ignore` annotation was present
+ */
+class IgnoredBecause extends \lang\XPException {
+    
+  /**
+   * Constructor
+   *
+   * @param  string $value The annotation value
+   */
+  public function __construct($value) {
+    parent::__construct($value ? (string)$value : 'n/a');
+  }
+
+  /**
+   * Return compound message of this exception.
+   *
+   * @return  string
+   */
+  public function compoundMessage() {
+    return nameof($this).'{ '.$this->message.' }';
+  }
+}

--- a/src/main/php/unittest/StopTests.class.php
+++ b/src/main/php/unittest/StopTests.class.php
@@ -1,0 +1,22 @@
+<?php namespace unittest;
+
+class StopTests extends \lang\XPException {
+
+  /**
+   * Constructor
+   *
+   * @param  lang.Throwable $reason
+   */
+  public function __construct($reason) {
+    parent::__construct($reason->compoundMessage());
+  }
+
+  /**
+   * Return compound message of this exception.
+   *
+   * @return string
+   */
+  public function compoundMessage() {
+    return nameof($this).'('.$this->message.')';
+  }
+}

--- a/src/main/php/unittest/TestCase.class.php
+++ b/src/main/php/unittest/TestCase.class.php
@@ -53,7 +53,11 @@ class TestCase extends \lang\Object {
    * @return  void
    */
   public function skip($reason, $prerequisites= []) {
-    throw new PrerequisitesNotMetError($reason, null, $prerequisites= []);
+    if ($prerequisites) {
+      throw new PrerequisitesNotMetError($reason, null, $prerequisites);
+    } else {
+      throw new IgnoredBecause($reason);
+    }
   }
 
   /**

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -257,7 +257,7 @@ class TestSuite extends \lang\Object {
     // Check for @ignore
     if ($method->hasAnnotation('ignore')) {
       $this->notifyListeners('testNotRun', [
-        $result->set($test, new TestNotRun($test, $method->getAnnotation('ignore')))
+        $result->set($test, new TestNotRun($test, new IgnoredBecause($method->getAnnotation('ignore'))))
       ]);
       return;
     }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -386,6 +386,8 @@ class TestSuite extends \lang\Object {
           $report('testFailed', TestAssertionFailed::class, $e);
         } else if ($e instanceof PrerequisitesNotMetError) {
           $report('testSkipped', TestPrerequisitesNotMet::class, $e);
+        } else if ($e instanceof IgnoredBecause) {
+          $report('testSkipped', TestNotRun::class, $e);
         } else {
           $report('testError', TestError::class, $e);
         }

--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -157,15 +157,17 @@ class DefaultListener  implements TestListener, ColorizingListener {
     } else if ($failed) {
       $this->out->writeLine(']');
       $indicator= $this->colored ? "\033[41;1;37m✗" : 'FAIL';
+    } else {
+      $this->out->writeLine(']');
+      $indicator= $this->colored ? "\033[42;1;37m✓" : 'OK';
+    }
 
-      // Show failed test details
+    // Show failed test details
+    if ($failed) {
       $this->out->writeLine();
       foreach ($result->failed as $failure) {
         $this->out->writeLine('F ', $failure);
       }
-    } else {
-      $this->out->writeLine(']');
-      $indicator= $this->colored ? "\033[42;1;37m✓" : 'OK';
     }
 
     $this->out->writeLinef(

--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -144,28 +144,33 @@ class DefaultListener  implements TestListener, ColorizingListener {
   /**
    * Called when a test run finishes.
    *
-   * @param   unittest.TestSuite suite
-   * @param   unittest.TestResult result
+   * @param  unittest.TestSuite $suite
+   * @param  unittest.TestResult $result
+   * @param  unittest.StopTests $stop
    */
-  public function testRunFinished(\unittest\TestSuite $suite, \unittest\TestResult $result) {
-    $this->out->writeLine(']');
-    
-    // Show failed test details
-    $fail= false;
-    if ($result->failureCount() > 0) {
+  public function testRunFinished(\unittest\TestSuite $suite, \unittest\TestResult $result, \unittest\StopTests $stopped= null) {
+    $failed= $result->failureCount();
+
+    if ($stopped) {
+      $this->out->writeLine('|');
+      $indicator= ($this->colored ? "\033[43;1;30m■ " : 'STOP ').$stopped->getMessage();
+    } else if ($failed) {
+      $this->out->writeLine(']');
+      $indicator= $this->colored ? "\033[41;1;37m✗" : 'FAIL';
+
+      // Show failed test details
       $this->out->writeLine();
       foreach ($result->failed as $failure) {
         $this->out->writeLine('F ', $failure);
       }
-      $fail= true;
+    } else {
+      $this->out->writeLine(']');
+      $indicator= $this->colored ? "\033[42;1;37m✓" : 'OK';
     }
 
     $this->out->writeLinef(
       "\n%s: %d/%d run (%d skipped), %d succeeded, %d failed%s",
-      ($this->colored
-        ? ($fail ? "\033[41;1;37m✗" : "\033[42;1;37m✓")
-        : ($fail ? 'FAIL' : 'OK')
-      ),
+      $indicator,
       $result->runCount(),
       $result->count(),
       $result->skipCount(),

--- a/src/main/php/xp/unittest/Runner.class.php
+++ b/src/main/php/xp/unittest/Runner.class.php
@@ -55,6 +55,7 @@ use xp\unittest\sources\PropertySource;
  *   -s {when}: Stop running when a certain event occurs. When may be:
  *     . "fail" - When the first test fails
  *     . "skip" - On the first skipped test
+ *     . "ignore" - When the first ignored test is encountered
  *
  * Tests can be one or more of:
  *
@@ -80,8 +81,9 @@ class Runner {
   ];
 
   private static $stop= [
-    'fail'  => StopListener::FAIL,
-    'skip'  => StopListener::SKIP
+    'fail'   => StopListener::FAIL,
+    'skip'   => StopListener::SKIP,
+    'ignore' => StopListener::IGNORE
   ];
 
   /**

--- a/src/main/php/xp/unittest/StopListener.class.php
+++ b/src/main/php/xp/unittest/StopListener.class.php
@@ -16,8 +16,9 @@ use unittest\StopTests;
  * Checks for given events and stops the run
  */
 class StopListener implements \unittest\TestListener {
-  const FAIL = 0x0001;
-  const SKIP = 0x0002;
+  const FAIL   = 0x0001;
+  const SKIP   = 0x0002;
+  const IGNORE = 0x0004;
 
   private $events;
 
@@ -100,7 +101,7 @@ class StopListener implements \unittest\TestListener {
    * @param  unittest.TestSkipped $ignore
    */
   public function testNotRun(TestSkipped $ignore) {
-    if ($this->events & self::SKIP) {
+    if ($this->events & self::IGNORE) {
       throw new StopTests($ignore->reason);
     }
   }

--- a/src/main/php/xp/unittest/StopListener.class.php
+++ b/src/main/php/xp/unittest/StopListener.class.php
@@ -1,0 +1,127 @@
+<?php namespace xp\unittest;
+
+use unittest\TestCase;
+use unittest\TestSuite;
+use unittest\TestResult;
+use unittest\TestFailure;
+use unittest\TestError;
+use unittest\TestWarning;
+use unittest\TestSuccess;
+use unittest\TestSkipped;
+use unittest\StopTests;
+
+/**
+ * Stop listener
+ * -------------
+ * Checks for given events and stops the run
+ */
+class StopListener implements \unittest\TestListener {
+  const FAIL = 0x0001;
+  const SKIP = 0x0002;
+
+  private $events;
+
+  /**
+   * Stop on certain events
+   *
+   * @param  int $events $Bitfield of FAIL and SKIP
+   */
+  public function __construct($events) {
+    $this->events= $events;
+  }
+
+  /**
+   * Called when a test case starts.
+   *
+   * @param  unittest.TestCase $case
+   */
+  public function testStarted(TestCase $case) {
+    // NOOP
+  }
+
+  /**
+   * Called when a test fails.
+   *
+   * @param  unittest.TestFailure $failure
+   */
+  public function testFailed(TestFailure $failure) {
+    if ($this->events & self::FAIL) {
+      throw new StopTests($failure->reason);
+    }
+  }
+
+  /**
+   * Called when a test errors.
+   *
+   * @param  unittest.TestError $error
+   */
+  public function testError(TestError $error) {
+    if ($this->events & self::FAIL) {
+      throw new StopTests($error->reason);
+    }
+  }
+
+  /**
+   * Called when a test raises warnings.
+   *
+   * @param  unittest.TestWarning $warning
+   */
+  public function testWarning(TestWarning $warning) {
+    if ($this->events & self::FAIL) {
+      throw new StopTests($warning->reason);
+    }
+  }
+  
+  /**
+   * Called when a test finished successfully.
+   *
+   * @param  unittest.TestSuccess $success
+   */
+  public function testSucceeded(TestSuccess $success) {
+    // NOOP
+  }
+  
+  /**
+   * Called when a test is not run because it is skipped due to a 
+   * failed prerequisite.
+   *
+   * @param  unittest.TestSkipped $skipped
+   */
+  public function testSkipped(TestSkipped $skipped) {
+    if ($this->events & self::SKIP) {
+      throw new StopTests($skipped->reason);
+    }
+  }
+
+  /**
+   * Called when a test is not run because it has been ignored by using
+   * the @ignore annotation.
+   *
+   * @param  unittest.TestSkipped $ignore
+   */
+  public function testNotRun(TestSkipped $ignore) {
+    if ($this->events & self::SKIP) {
+      throw new StopTests($ignore->reason);
+    }
+  }
+
+  /**
+   * Called when a test run starts.
+   *
+   * @param  unittest.TestSuite $suite
+   */
+  public function testRunStarted(TestSuite $suite) {
+    // NOOP
+  }
+  
+  /**
+   * Called when a test run finishes.
+   *
+   * @param  unittest.TestSuite $suite
+   * @param  unittest.TestResult $result
+   * @param  unittest.StopTests $stop
+   */
+  public function testRunFinished(TestSuite $suite, TestResult $result, StopTests $stop= null) {
+    // NOOP
+  }
+}

--- a/src/main/php/xp/unittest/StopListener.class.php
+++ b/src/main/php/xp/unittest/StopListener.class.php
@@ -25,7 +25,7 @@ class StopListener implements \unittest\TestListener {
   /**
    * Stop on certain events
    *
-   * @param  int $events $Bitfield of FAIL and SKIP
+   * @param  int $events Bitfield of FAIL, SKIP and IGNORE constants
    */
   public function __construct($events) {
     $this->events= $events;

--- a/src/main/php/xp/unittest/VerboseListener.class.php
+++ b/src/main/php/xp/unittest/VerboseListener.class.php
@@ -102,8 +102,9 @@ class VerboseListener implements TestListener {
    *
    * @param   unittest.TestSuite suite
    * @param   unittest.TestResult result
+   * @param  unittest.StopTests $stop
    */
-  public function testRunFinished(\unittest\TestSuite $suite, \unittest\TestResult $result) {
+  public function testRunFinished(\unittest\TestSuite $suite, \unittest\TestResult $result, \unittest\StopTests $stopped= null) {
 
     // Details
     if ($result->successCount() > 0) {
@@ -127,7 +128,7 @@ class VerboseListener implements TestListener {
 
     $this->out->writeLinef(
       "\n===> %s: %d run (%d skipped), %d succeeded, %d failed",
-      $result->failureCount() ? 'FAIL' : 'OK',
+      $stopped ? 'STOP '.$stopped->getMessage() : ($result->failureCount() ? 'FAIL' : 'OK'),
       $result->runCount(),
       $result->skipCount(),
       $result->successCount(),

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -347,20 +347,31 @@ class UnittestRunnerTest extends TestCase {
   #[@test]
   public function stop_after_failing_test() {
     $command= newinstance(TestCase::class, ['fails'], [
-      '#[@test] fails' => function() { $this->assertTrue(false); }
+      '#[@test] fails' => function() { $this->fail('Test'); }
     ]);
     $return= $this->runner->run(['-s', 'fail', nameof($command)]);
     $this->assertEquals(1, $return);
     $this->assertEquals('', $this->err->getBytes());
-    $this->assertOnStream($this->out, 'AssertionFailedError{ expected [true] but was [false] using: \'===\' }: 1/1 run (0 skipped), 0 succeeded, 1 failed');
+    $this->assertOnStream($this->out, 'AssertionFailedError{ Test }: 1/1 run (0 skipped), 0 succeeded, 1 failed');
+  }
+
+  #[@test]
+  public function stop_after_skipped_test() {
+    $command= newinstance(TestCase::class, ['skipped'], [
+      '#[@test] skipped' => function() { $this->skip('Test', ['prerequisite']); }
+    ]);
+    $return= $this->runner->run(['-s', 'skip', nameof($command)]);
+    $this->assertEquals(0, $return);
+    $this->assertEquals('', $this->err->getBytes());
+    $this->assertOnStream($this->out, 'PrerequisitesNotMetError (Test) { prerequisites: ["prerequisite"] }: 0/1 run (1 skipped), 0 succeeded, 0 failed');
   }
 
   #[@test]
   public function stop_after_ignored_test() {
-    $command= newinstance(TestCase::class, ['fails'], [
+    $command= newinstance(TestCase::class, ['ignored'], [
       '#[@test, @ignore("Test")] ignored' => function() { /* ... */ }
     ]);
-    $return= $this->runner->run(['-s', 'skip', nameof($command)]);
+    $return= $this->runner->run(['-s', 'ignore', nameof($command)]);
     $this->assertEquals(0, $return);
     $this->assertEquals('', $this->err->getBytes());
     $this->assertOnStream($this->out, 'IgnoredBecause{ Test }: 0/1 run (1 skipped), 0 succeeded, 0 failed');

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -343,4 +343,26 @@ class UnittestRunnerTest extends TestCase {
       $class->getField('options')->get(null)
     );
   }
+
+  #[@test]
+  public function stop_after_failing_test() {
+    $command= newinstance(TestCase::class, ['fails'], [
+      '#[@test] fails' => function() { $this->assertTrue(false); }
+    ]);
+    $return= $this->runner->run(['-s', 'fail', nameof($command)]);
+    $this->assertEquals(1, $return);
+    $this->assertEquals('', $this->err->getBytes());
+    $this->assertOnStream($this->out, 'AssertionFailedError{ expected [true] but was [false] using: \'===\' }: 1/1 run (0 skipped), 0 succeeded, 1 failed');
+  }
+
+  #[@test]
+  public function stop_after_ignored_test() {
+    $command= newinstance(TestCase::class, ['fails'], [
+      '#[@test, @ignore("Test")] ignored' => function() { /* ... */ }
+    ]);
+    $return= $this->runner->run(['-s', 'skip', nameof($command)]);
+    $this->assertEquals(0, $return);
+    $this->assertEquals('', $this->err->getBytes());
+    $this->assertOnStream($this->out, 'IgnoredBecause{ Test }: 0/1 run (1 skipped), 0 succeeded, 0 failed');
+  }
 }


### PR DESCRIPTION
This pull request implement issue #3 and adds a facility for stopping the test run when a certain event occurs.
## Usage
-  -s {when}: Stop running when a certain event occurs. When may be:
  - "fail" - When the first test fails
  - "skip" - On the first skipped test
  - "ignore" - When the first ignored test is encountered
## Example

``` php
class ExampleTest extends \unittest\TestCase {

  #[@test]
  public function skipped() {
    $this->skip('Because I can');
  }

  #[@test]
  public function fails() {
    $this->fail('Because I do');
  }

  #[@test]
  public function succeeds() {
    // NOOP
  }
}
```
## Regular run

``` sh
$ unittest ExampleTest.class.php
[SF.]

F unittest.TestAssertionFailed(test= ExampleTest::fails, time= 0.000 seconds) {
  unittest.AssertionFailedError{ Because I do }
    at ExampleTest::fails() [line 0 of StackTraceElement.class.php]
# ...
 }

✗: 2/3 run (1 skipped), 1 succeeded, 1 failed
Memory used: 1414.89 kB (1469.10 kB peak)
Time taken: 0.000 seconds
```
## With "stop on skip"

``` sh
$ unittest -s skip ExampleTest.class.php
[S|

■ unittest.IgnoredBecause{ Because I can }: 0/1 run (1 skipped), 0 succeeded, 0 failed
Memory used: 1405.65 kB (1469.30 kB peak)
Time taken: 0.000 seconds
```
## With "stop on fail"

``` sh
$ unittest -s fail ExampleTest.class.php
[SF|

F unittest.TestAssertionFailed(test= ExampleTest::fails, time= 0.000 seconds) {
  unittest.AssertionFailedError{ Because I do }
    at ExampleTest::fails() [line 0 of StackTraceElement.class.php]
# ...
 }

■ unittest.AssertionFailedError{ Because I do }: 1/2 run (1 skipped), 0 succeeded, 1 failed
Memory used: 1424.54 kB (1470.46 kB peak)
Time taken: 0.000 seconds

```
