### PR TITLE
Use symbols that also work in Windows console

### DIFF
--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -156,10 +156,10 @@ class DefaultListener  implements TestListener, ColorizingListener {
       $indicator= ($this->colored ? "\033[43;1;30m■ " : 'STOP ').$stopped->getMessage();
     } else if ($failed) {
       $this->out->writeLine(']');
-      $indicator= $this->colored ? "\033[41;1;37m✗" : 'FAIL';
+      $indicator= $this->colored ? "\033[41;1;37m×" : 'FAIL';
     } else {
       $this->out->writeLine(']');
-      $indicator= $this->colored ? "\033[42;1;37m✓" : 'OK';
+      $indicator= $this->colored ? "\033[42;1;37m♥" : 'OK';
     }
 
     // Show failed test details


### PR DESCRIPTION
Unicode support is at best "flaky" there as far as I see, so changing to character that also work there:
- **Failure**: `✗` -> `×`
- **Success**: `✓` -> `♥`

Verified to work in a MinTTY, also.

![unittest-colors-and-symbols](https://cloud.githubusercontent.com/assets/696742/12078725/5e3b8778-b21d-11e5-9957-dfde71449574.png)
