### PR TITLE
Refactor: Use xp-forge/mirrors for reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^6.10",
     "xp-framework/io-collections": "^6.5",
-    "xp-forge/mirrors": "^1.6",
+    "xp-forge/mirrors": "^2.0",
     "php" : ">=5.5.0"
   },
   "bin": ["bin/xp.xp-framework.unittest.test"],

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require" : {
     "xp-framework/core": "^6.10",
     "xp-framework/io-collections": "^6.5",
+    "xp-forge/mirrors": "^1.6",
     "php" : ">=5.5.0"
   },
   "bin": ["bin/xp.xp-framework.unittest.test"],

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^6.10",
     "xp-framework/io-collections": "^6.5",
-    "xp-forge/mirrors": "^2.0",
+    "xp-forge/mirrors": "^2.1",
     "php" : ">=5.5.0"
   },
   "bin": ["bin/xp.xp-framework.unittest.test"],

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -1,27 +1,27 @@
 <?php namespace unittest;
 
-use lang\XPClass;
+use lang\mirrors\TypeMirror;
 use lang\IllegalStateException;
 
 abstract class TestGroup {
   protected static $base;
 
   static function __static() {
-    self::$base= new XPClass(TestCase::class);
+    self::$base= new TypeMirror(TestCase::class);
   }
 
   /**
    * Verify test method doesn't override a special method from TestCase
    *
-   * @param  lang.reflect.Method $method
+   * @param  lang.mirrors.Method $method
    * @return lang.IllegalStateException
    */
   protected function cannotOverride($method) {
     return new IllegalStateException(sprintf(
       'Cannot override %s::%s with test method in %s',
-      self::$base->getName(),
-      $method->getName(),
-      $method->getDeclaringClass()->getName()
+      self::$base->name(),
+      $method->name(),
+      $method->declaredIn()->name()
     ));
   }
 

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -16,7 +16,7 @@ class TestInstance extends TestGroup {
    * @throws lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function __construct($instance) {
-    $mirror= new TypeMirror(typeof($instance));
+    $mirror= new TypeMirror(get_class($instance));
     if (!$mirror->methods()->provides($instance->name)) {
       throw new MethodNotImplementedException('Test method does not exist', $instance->name);
     }

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -1,6 +1,7 @@
 <?php namespace unittest;
 
 use lang\MethodNotImplementedException;
+use lang\mirrors\TypeMirror;
 
 class TestInstance extends TestGroup {
   private $instance;
@@ -15,13 +16,13 @@ class TestInstance extends TestGroup {
    * @throws lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function __construct($instance) {
-    $class= $instance->getClass();
-    if (!$class->hasMethod($instance->name)) {
+    $mirror= new TypeMirror(typeof($instance));
+    if (!$mirror->methods()->provides($instance->name)) {
       throw new MethodNotImplementedException('Test method does not exist', $instance->name);
     }
 
-    if (self::$base->hasMethod($instance->name)) {
-      throw $this->cannotOverride($class->getMethod($instance->name));
+    if (self::$base->methods()->provides($instance->name)) {
+      throw $this->cannotOverride($mirror->method($instance->name));
     }
 
     $this->instance= $instance;

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -1,7 +1,7 @@
 <?php namespace unittest;
 
 use lang\MethodNotImplementedException;
-use lang\mirrors\TypeMirror;
+use lang\mirrors\InstanceMirror;
 
 class TestInstance extends TestGroup {
   private $instance;
@@ -16,7 +16,7 @@ class TestInstance extends TestGroup {
    * @throws lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function __construct($instance) {
-    $mirror= new TypeMirror(get_class($instance));
+    $mirror= new InstanceMirror($instance);
     if (!$mirror->methods()->provides($instance->name)) {
       throw new MethodNotImplementedException('Test method does not exist', $instance->name);
     }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -144,9 +144,10 @@ class TestSuite extends \lang\Object {
    *
    * @param  unittest.TestCase test
    * @param  var annotation
+   * @param  lang.types.TypeMirror self
    * @return var values a traversable structure
    */
-  protected function valuesFor($test, $annotation) {
+  protected function valuesFor($test, $annotation, $self) {
     if (!is_array($annotation)) {               // values("source")
       $source= $annotation;
       $args= [];
@@ -161,14 +162,11 @@ class TestSuite extends \lang\Object {
     // "self::method" -> static method of the test class, and "method" 
     // -> the run test's instance method
     if (false === ($p= strpos($source, '::'))) {
-      return (new InstanceMirror($test))->method($source)->invoke($test, $args);
+      return $self->method($source)->invoke($test, $args);
     }
+
     $ref= substr($source, 0, $p);
-    if ('self' === $ref) {
-      $mirror= new InstanceMirror($test);
-    } else {
-      $mirror= new TypeMirror($ref);
-    }
+    $mirror= 'self' === $ref ? $self : new TypeMirror($ref);
     return $mirror->method(substr($source, $p + 2))->invoke(null, $args);
   }
 
@@ -260,7 +258,7 @@ class TestSuite extends \lang\Object {
     if ($annotations->provides('values')) {
       $annotation= $annotations->named('values')->value();
       $variation= true;
-      $values= $this->valuesFor($test, $annotation);
+      $values= $this->valuesFor($test, $annotation, $mirror);
     } else {
       $variation= false;
       $values= [[]];

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -10,6 +10,7 @@ use lang\Throwable;
 use lang\Error;
 use lang\mirrors\TargetInvocationException;
 use lang\mirrors\TypeMirror;
+use lang\mirrors\InstanceMirror;
 
 /**
  * Test suite
@@ -160,11 +161,11 @@ class TestSuite extends \lang\Object {
     // "self::method" -> static method of the test class, and "method" 
     // -> the run test's instance method
     if (false === ($p= strpos($source, '::'))) {
-      return (new TypeMirror(get_class($test)))->method($source)->invoke($test, $args);
+      return (new InstanceMirror($test))->method($source)->invoke($test, $args);
     }
     $ref= substr($source, 0, $p);
     if ('self' === $ref) {
-      $mirror= new TypeMirror(get_class($test));
+      $mirror= new InstanceMirror($test);
     } else {
       $mirror= new TypeMirror($ref);
     }
@@ -223,7 +224,7 @@ class TestSuite extends \lang\Object {
    * @throws  lang.MethodNotImplementedException
    */
   protected function runInternal($test, $result) {
-    $mirror= new TypeMirror(get_class($test));
+    $mirror= new InstanceMirror($test);
     $method= $mirror->method($test->name);
     $annotations= $method->annotations(); 
     $this->notifyListeners('testStarted', [$test]);
@@ -480,7 +481,7 @@ class TestSuite extends \lang\Object {
    * @throws  lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function runTest(TestCase $test) {
-    $mirror= new TypeMirror(get_class($test));
+    $mirror= new InstanceMirror($test);
     if (!$mirror->methods()->provides($test->name)) {
       throw new MethodNotImplementedException('Test method does not exist', $test->name);
     }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -220,11 +220,11 @@ class TestSuite extends \lang\Object {
    *
    * @param   unittest.TestCase test
    * @param   unittest.TestResult result
+   * @param   lang.mirrors.TypeMirror mirror
    * @return  void
    * @throws  lang.MethodNotImplementedException
    */
-  protected function runInternal($test, $result) {
-    $mirror= new InstanceMirror($test);
+  protected function runInternal($test, $result, $mirror) {
     $method= $mirror->method($test->name);
     $annotations= $method->annotations(); 
     $this->notifyListeners('testStarted', [$test]);
@@ -491,7 +491,7 @@ class TestSuite extends \lang\Object {
     $result= new TestResult();
     try {
       $this->beforeClass($mirror);
-      $this->runInternal($test, $result);
+      $this->runInternal($test, $result, $mirror);
       $this->afterClass($mirror);
       $this->notifyListeners('testRunFinished', [$this, $result, null]);
     } catch (PrerequisitesNotMetError $e) {
@@ -530,7 +530,7 @@ class TestSuite extends \lang\Object {
 
         foreach ($groups as $group) {
           foreach ($group->tests() as $test) {
-            $this->runInternal($test, $result);
+            $this->runInternal($test, $result, $mirror);
           }
         }
         $this->afterClass($mirror);

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -356,6 +356,17 @@ class SuiteTest extends TestCase {
   }
 
   #[@test]
+  public function native_exceptions_make_test_fail() {
+    $test= newinstance(TestCase::class, ['fixture'], [
+      '#[@test] fixture' => function() { throw new \Exception('Test'); }
+    ]);
+    $this->assertInstanceOf(
+      'lang.Error',
+      $this->suite->runTest($test)->failed[$test->hashCode()]->reason
+    );
+  }
+
+  #[@test, @action(new RuntimeVersion('>=7.0.0'))]
   public function native_php7_errors_make_test_fail() {
     $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $null= null; $null->method(); }

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -356,17 +356,6 @@ class SuiteTest extends TestCase {
   }
 
   #[@test]
-  public function native_exceptions_make_test_fail() {
-    $test= newinstance(TestCase::class, ['fixture'], [
-      '#[@test] fixture' => function() { throw new \Exception('Test'); }
-    ]);
-    $this->assertInstanceOf(
-      'lang.XPException',
-      $this->suite->runTest($test)->failed[$test->hashCode()]->reason
-    );
-  }
-
-  #[@test, @action(new RuntimeVersion('>=7.0.0'))]
   public function native_php7_errors_make_test_fail() {
     $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test] fixture' => function() { $null= null; $null->method(); }


### PR DESCRIPTION
Supersedes #5 
## Performance

Before:

``` sh
Timm@slate ~/devel/xp/unittest [master]
$ xp test src/test/php/
# ...

♥: 388/399 run (11 skipped), 388 succeeded, 0 failed
Memory used: 5220.40 kB (5284.60 kB peak)
Time taken: 0.126 seconds
```

``` sh
Timm@slate ~/devel/xp/core [master]
$ xp test src/test/config/unittest/core.ini
# ...

♥: 2132/2161 run (29 skipped), 2132 succeeded, 0 failed
Memory used: 9823.09 kB (10567.55 kB peak)
Time taken: 1.556 seconds
```

After, and including use of https://github.com/xp-forge/mirrors/pull/34:

``` sh
Timm@slate ~/devel/xp/unittest [refactor/use-mirrors]
$ xp test src/test/php/
# ...

♥: 388/399 run (11 skipped), 388 succeeded, 0 failed
Memory used: 6155.25 kB (7908.18 kB peak)
Time taken: 0.211 seconds
```

``` sh
Timm@slate ~/devel/xp/core [master]
$ xp test src/test/config/unittest/core.ini
# ...

♥: 2132/2161 run (29 skipped), 2132 succeeded, 0 failed
Memory used: 12420.11 kB (12897.98 kB peak)
Time taken: 1.625 seconds
```

_Before the refactoring to xp-forge/mirrors, the figures are  7867.74 kB (8337.23 kB peak) and 0.518 seconds!_
