### PR TITLE
XP9 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "Unittests for the XP Framework",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.10",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.10",
     "xp-framework/io-collections": "^7.0 | ^6.5",
     "php" : ">=5.5.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.10",
-    "xp-framework/io-collections": "^7.0 | ^6.5",
+    "xp-framework/io-collections": "^8.0 | ^7.0 | ^6.5",
     "php" : ">=5.6.0"
   },
   "bin": ["bin/xp.xp-framework.unittest.test"],

--- a/src/main/php/unittest/ComparisonFailedMessage.class.php
+++ b/src/main/php/unittest/ComparisonFailedMessage.class.php
@@ -88,9 +88,9 @@ class ComparisonFailedMessage implements AssertionFailedMessage {
     } else {
       $te= typeof($this->expect);
       $ta= typeof($this->actual);
-      $include= !Objects::equal($te, $ta);
-      $expect= $this->stringOf($this->expect, $include ? $te : null);
-      $actual= $this->stringOf($this->actual, $include ? $ta : null);
+      $exclude= $te->equals($ta);
+      $expect= $this->stringOf($this->expect, $exclude ? null : $te);
+      $actual= $this->stringOf($this->actual, $exclude ? null : $ta);
     }
 
     return sprintf(

--- a/src/main/php/unittest/ComparisonFailedMessage.class.php
+++ b/src/main/php/unittest/ComparisonFailedMessage.class.php
@@ -2,6 +2,7 @@
 
 use lang\Generic;
 use lang\Value;
+use util\Objects;
 
 /**
  * The message for an assertion failure
@@ -9,7 +10,7 @@ use lang\Value;
  * @see  xp://unittest.AssertionFailedError
  * @test xp://net.xp_framework.unittest.tests.AssertionMessagesTest
  */
-class ComparisonFailedMessage extends \lang\Object implements AssertionFailedMessage {
+class ComparisonFailedMessage implements AssertionFailedMessage {
   const CONTEXT_LENGTH = 20;
 
   protected $comparison;
@@ -85,7 +86,7 @@ class ComparisonFailedMessage extends \lang\Object implements AssertionFailedMes
     } else {
       $te= typeof($this->expect);
       $ta= typeof($this->actual);
-      $include= !$te->equals($ta);
+      $include= !Objects::equal($te, $ta);
       $expect= $this->stringOf($this->expect, $include ? $te : null);
       $actual= $this->stringOf($this->actual, $include ? $ta : null);
     }

--- a/src/main/php/unittest/ComparisonFailedMessage.class.php
+++ b/src/main/php/unittest/ComparisonFailedMessage.class.php
@@ -33,12 +33,20 @@ class ComparisonFailedMessage implements AssertionFailedMessage {
   /**
    * Creates a string representation of a given value.
    *
-   * @param   var value
-   * @param   string type NULL if type name should be not included.
-   * @return  string
+   * @param  var $value
+   * @param  string|lang.Type $type NULL if type name should be not included.
+   * @return string
    */
   protected function stringOf($value, $type) {
-    return (null === $value || null === $type ? '' : $type.':').\xp::stringOf($value);
+    if (null === $value) {
+      return 'null';
+    } else if ($value instanceof Value || $value instanceof Generic) {
+      return $value->toString();
+    } else if ($type) {
+      return $type.':'.Objects::stringOf($value);
+    } else {
+      return Objects::stringOf($value);
+    }
   }
 
   /**
@@ -77,12 +85,6 @@ class ComparisonFailedMessage implements AssertionFailedMessage {
       }
       $expect= $this->compact($this->expect, $i, $j+ 1, $le);
       $actual= $this->compact($this->actual, $i, $k+ 1, $la);
-    } else if ($this->expect instanceof Generic && $this->actual instanceof Generic) {
-      $expect= $this->stringOf($this->expect, null);
-      $actual= $this->stringOf($this->actual, null);
-    } else if ($this->expect instanceof Value && $this->actual instanceof Value) {
-      $expect= $this->expect->toString();
-      $actual= $this->actual->toString();
     } else {
       $te= typeof($this->expect);
       $ta= typeof($this->actual);

--- a/src/main/php/unittest/FormattedMessage.class.php
+++ b/src/main/php/unittest/FormattedMessage.class.php
@@ -5,7 +5,7 @@
  *
  * @see  xp://unittest.AssertionFailedError
  */
-class FormattedMessage extends \lang\Object implements AssertionFailedMessage {
+class FormattedMessage implements AssertionFailedMessage {
   protected $format;
   protected $args;
 

--- a/src/main/php/unittest/TestAssertionFailed.class.php
+++ b/src/main/php/unittest/TestAssertionFailed.class.php
@@ -1,11 +1,13 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Indicates a test failed
  *
  * @see   xp://unittest.TestFailure
  */
-class TestAssertionFailed extends \lang\Object implements TestFailure {
+class TestAssertionFailed implements TestFailure {
   public
     $reason   = null,
     $test     = null,
@@ -46,5 +48,20 @@ class TestAssertionFailed extends \lang\Object implements TestFailure {
       $this->elapsed,
       \xp::stringOf($this->reason, '  ')
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->test, $this->reason]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/TestCase.class.php
+++ b/src/main/php/unittest/TestCase.class.php
@@ -7,7 +7,7 @@ use util\Objects;
  *
  * @see   php://assert
  */
-class TestCase extends \lang\Object {
+class TestCase implements \lang\Value {
   public $name= '';
     
   /**
@@ -169,13 +169,18 @@ class TestCase extends \lang\Object {
     return nameof($this).'<'.$this->name.'>';
   }
 
+  /** @return string */
+  public function hashCode() {
+    return 'T'.$this->name;
+  }
+
   /**
-   * Returns whether an object is equal to this testcase
+   * Compares this test suite to a given value
    *
-   * @param   var $cmp
-   * @return  bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->name == $cmp->name;
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->name, $value->name) : 1;
   }
 }

--- a/src/main/php/unittest/TestCase.class.php
+++ b/src/main/php/unittest/TestCase.class.php
@@ -171,7 +171,7 @@ class TestCase implements \lang\Value {
 
   /** @return string */
   public function hashCode() {
-    return 'T'.$this->name;
+    return 'T'.md5(get_class($this).$this->name);
   }
 
   /**

--- a/src/main/php/unittest/TestError.class.php
+++ b/src/main/php/unittest/TestError.class.php
@@ -1,11 +1,13 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Indicates a test failed
  *
  * @see   xp://unittest.TestFailure
  */
-class TestError extends \lang\Object implements TestFailure {
+class TestError implements TestFailure {
   public
     $reason   = null,
     $test     = null,
@@ -44,7 +46,22 @@ class TestError extends \lang\Object implements TestFailure {
       nameof($this),
       $this->test->getName(true),
       $this->elapsed,
-      \xp::stringOf($this->reason, '  ')
+      str_replace("\n", "\n  ", $this->reason->toString())
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->test, $this->reason]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/TestExpectationMet.class.php
+++ b/src/main/php/unittest/TestExpectationMet.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://unittest.TestSuccess
  */
-class TestExpectationMet extends \lang\Object implements TestSuccess {
+class TestExpectationMet implements TestSuccess {
   public
     $test     = null,
     $elapsed  = 0.0;
@@ -42,5 +42,20 @@ class TestExpectationMet extends \lang\Object implements TestSuccess {
       $this->test->getName(true),
       $this->elapsed
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return $this->test->hashCode();
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->test->compareTo($value->test) : 1;
   }
 }

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -15,7 +15,7 @@ class TestInstance extends TestGroup {
    * @throws lang.MethodNotImplementedException in case given argument is not a valid testcase
    */
   public function __construct($instance) {
-    $class= $instance->getClass();
+    $class= typeof($instance);
     if (!$class->hasMethod($instance->name)) {
       throw new MethodNotImplementedException('Test method does not exist', $instance->name);
     }

--- a/src/main/php/unittest/TestNotRun.class.php
+++ b/src/main/php/unittest/TestNotRun.class.php
@@ -5,7 +5,7 @@
  *
  * @see   xp://unittest.TestSkipped
  */
-class TestNotRun extends \lang\Object implements TestSkipped {
+class TestNotRun implements TestSkipped {
   public
     $reason   = '',
     $test     = null;
@@ -42,5 +42,20 @@ class TestNotRun extends \lang\Object implements TestSkipped {
       $this->test->getName(true),
       \xp::stringOf($this->reason, '  ')
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->test, $this->reason]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/TestOutcome.class.php
+++ b/src/main/php/unittest/TestOutcome.class.php
@@ -4,7 +4,7 @@
  * Outcome from a test
  *
  */
-interface TestOutcome {
+interface TestOutcome extends \lang\Value {
 
   /**
    * Returns elapsed time

--- a/src/main/php/unittest/TestPrerequisitesNotMet.class.php
+++ b/src/main/php/unittest/TestPrerequisitesNotMet.class.php
@@ -1,11 +1,13 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Indicates a test was skipped
  *
  * @see      xp://unittest.TestSkipped
  */
-class TestPrerequisitesNotMet extends \lang\Object implements TestSkipped {
+class TestPrerequisitesNotMet implements TestSkipped {
   public
     $reason   = null,
     $test     = null,
@@ -46,5 +48,20 @@ class TestPrerequisitesNotMet extends \lang\Object implements TestSkipped {
       $this->elapsed,
       \xp::stringOf($this->reason, '  ')
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->test, $this->reason]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/TestResult.class.php
+++ b/src/main/php/unittest/TestResult.class.php
@@ -1,11 +1,13 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Test result
  *
  * @see   xp://unittest.TestSuite
  */
-class TestResult extends \lang\Object {
+class TestResult implements \lang\Value {
   public
     $succeeded    = [],
     $failed       = [],
@@ -177,5 +179,25 @@ class TestResult extends \lang\Object {
       }
     }
     return $str.$div."\n";
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->succeeded, $this->failed, $this->skipped]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    if (!($value instanceof self)) return 1;
+
+    return Objects::compare(
+      [$this->succeeded, $this->failed, $this->skipped],
+      [$value->succeeded, $value->failed, $this->skipped]
+    );
   }
 }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -22,7 +22,6 @@ use util\Objects;
 class TestSuite implements \lang\Value {
   protected $listeners= [];
   private $sources= [];
-  private $numTests= 0;
 
   /**
    * Add a test

--- a/src/main/php/unittest/TestWarning.class.php
+++ b/src/main/php/unittest/TestWarning.class.php
@@ -1,11 +1,13 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Indicates a test failed
  *
  * @see      xp://unittest.TestFailure
  */
-class TestWarning extends \lang\Object implements TestFailure {
+class TestWarning implements TestFailure {
   public
     $reason   = null,
     $test     = null,
@@ -33,11 +35,7 @@ class TestWarning extends \lang\Object implements TestFailure {
     return $this->elapsed;
   }
 
-  /**
-   * Return a string representation of this class
-   *
-   * @return  string
-   */
+  /** @return string */
   public function toString() {
     return sprintf(
       "%s(test= %s, time= %.3f seconds) {\n  %s\n }",
@@ -46,5 +44,20 @@ class TestWarning extends \lang\Object implements TestFailure {
       $this->elapsed,
       \xp::stringOf($this->reason, '  ')
     );
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([null => $this->test] + $this->reason);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/actions/ExtensionAvailable.class.php
+++ b/src/main/php/unittest/actions/ExtensionAvailable.class.php
@@ -10,7 +10,7 @@ use unittest\TestCase;
  * @test  xp://net.xp_framework.unittest.tests.ExtensionAvailableTest
  * @see   xp://lang.Runtime#extensionAvailable
  */
-class ExtensionAvailable extends \lang\Object implements \unittest\TestAction {
+class ExtensionAvailable implements \unittest\TestAction {
   protected $extension= '';
 
   /**

--- a/src/main/php/unittest/actions/IsPlatform.class.php
+++ b/src/main/php/unittest/actions/IsPlatform.class.php
@@ -13,7 +13,7 @@ use unittest\PrerequisitesNotMetError;
  *
  * @test  xp://net.xp_framework.unittest.tests.IsPlatformTest
  */
-class IsPlatform extends \lang\Object implements \unittest\TestAction {
+class IsPlatform implements \unittest\TestAction {
   protected $platform= '';
   protected static $os= '';
 

--- a/src/main/php/unittest/actions/RuntimeVersion.class.php
+++ b/src/main/php/unittest/actions/RuntimeVersion.class.php
@@ -9,7 +9,7 @@ use unittest\TestCase;
  * @test xp://net.xp_framework.unittest.tests.RuntimeVersionTest
  * @see  http://getcomposer.org/doc/01-basic-usage.md#package-versions
  */
-class RuntimeVersion extends \lang\Object implements \unittest\TestAction {
+class RuntimeVersion implements \unittest\TestAction {
   protected $compare= [];
 
   /**

--- a/src/main/php/unittest/actions/VerifyThat.class.php
+++ b/src/main/php/unittest/actions/VerifyThat.class.php
@@ -9,7 +9,7 @@ use lang\Throwable;
  *
  * @test  xp://net.xp_framework.unittest.tests.VerifyThatTest
  */
-class VerifyThat extends \lang\Object implements \unittest\TestAction, \unittest\TestClassAction {
+class VerifyThat implements \unittest\TestAction, \unittest\TestClassAction {
   protected $verify;
   protected $prerequisite;
 

--- a/src/main/php/unittest/package-info.xp
+++ b/src/main/php/unittest/package-info.xp
@@ -7,7 +7,7 @@
  * =======
  * Given the following class (abbreviated):
  * <code>
- *   class Calculator extends Object {
+ *   class Calculator {
  *     
  *     public function add($a, $b) {
  *       return $a + $b;

--- a/src/main/php/xp/unittest/ColoredBarListener.class.php
+++ b/src/main/php/xp/unittest/ColoredBarListener.class.php
@@ -14,7 +14,7 @@ use io\streams\OutputStreamWriter;
  *   information out instantly)
  *
  */
-class ColoredBarListener extends \lang\Object implements \unittest\TestListener {
+class ColoredBarListener implements \unittest\TestListener {
   const PROGRESS_WIDTH= 10;
   private $out= null;
   private $cur, $sum, $len, $status;

--- a/src/main/php/xp/unittest/sources/AbstractSource.class.php
+++ b/src/main/php/xp/unittest/sources/AbstractSource.class.php
@@ -3,7 +3,7 @@
 /**
  * Source
  */
-abstract class AbstractSource extends \lang\Object {
+abstract class AbstractSource {
 
   /**
    * Provide tests to test suite

--- a/src/test/php/unittest/tests/AssertionMessagesTest.class.php
+++ b/src/test/php/unittest/tests/AssertionMessagesTest.class.php
@@ -58,8 +58,8 @@ class AssertionMessagesTest extends TestCase {
   #[@test]
   public function differentTypes() {
     $this->assertFormatted(
-      'expected [unittest.tests.Value:unittest.tests.Value(1)] but was [unittest.tests.AssertionMessagesTest:unittest.tests.AssertionMessagesTest<differentTypes>] using: \'equals\'',
-      new ComparisonFailedMessage('equals', new Value(1), $this)
+      'expected [unittest.tests.Value(1)] but was [int:1] using: \'equals\'',
+      new ComparisonFailedMessage('equals', new Value(1), 1)
     );
   }
 
@@ -82,7 +82,7 @@ class AssertionMessagesTest extends TestCase {
   #[@test]
   public function nullVsObject() {
     $this->assertFormatted(
-      "expected [unittest.TestCase:unittest.TestCase<b>] but was [null] using: 'equals'",
+      "expected [unittest.TestCase<b>] but was [null] using: 'equals'",
       new ComparisonFailedMessage('equals', new TestCase('b'), null)
     );
   }

--- a/src/test/php/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/unittest/tests/AssertionsTest.class.php
@@ -1,7 +1,5 @@
 <?php namespace unittest\tests;
  
-use lang\Object;
-use lang\Generic;
 use unittest\TestCase;
 use unittest\AssertionFailedError;
 
@@ -56,13 +54,15 @@ class AssertionsTest extends TestCase {
   }
 
   #[@test]
-  public function equalsMethodIsInvoked() {
-    $instance= newinstance(Object::class, [], '{
+  public function compareToMethodIsInvoked() {
+    $instance= newinstance(\lang\Value::class, [], '{
       public $equalsInvoked= 0;
 
-      public function equals($other) {
+      public function toString() { return nameof($this)."@".$this->equalsInvoked; }
+      public function hashCode() { return "V".$this->equalsInvoked; }
+      public function compareTo($other) {
         $this->equalsInvoked++;
-        return $other instanceof self && $this->equalsInvoked == $other->equalsInvoked;
+        return $other instanceof self ? $this->equalsInvoked - $other->equalsInvoked : 1;
       }
     }');
    
@@ -162,36 +162,28 @@ class AssertionsTest extends TestCase {
 
   #[@test]
   public function thisIsAnInstanceOfObject() {
-    $this->assertInstanceOf(Object::class, $this);
+    $this->assertInstanceOf(\lang\Value::class, $this);
   }    
 
   #[@test]
   public function objectIsAnInstanceOfObject() {
-    $this->assertInstanceOf(Object::class, new \lang\Object());
+    $this->assertInstanceOf(\lang\Value::class, new Value(2));
   }    
 
   #[@test, @expect(
   #  class= AssertionFailedError::class,
-  #  withMessage= 'expected ["unittest.tests.Value"] but was ["lang.Object"]'
+  #  withMessage= 'expected ["lang.Value"] but was ["int"]'
   #)]
-  public function objectIsNotAnInstanceOfString() {
-    $this->assertInstanceOf(Value::class, new \lang\Object());
+  public function zeroIsNotAnInstanceOfValue() {
+    $this->assertInstanceOf(\lang\Value::class, 0);
   }    
 
   #[@test, @expect(
   #  class= AssertionFailedError::class,
-  #  withMessage= 'expected ["lang.Generic"] but was ["int"]'
+  #  withMessage= 'expected ["lang.Value"] but was ["void"]'
   #)]
-  public function zeroIsNotAnInstanceOfGeneric() {
-    $this->assertInstanceOf(Generic::class, 0);
-  }    
-
-  #[@test, @expect(
-  #  class= AssertionFailedError::class,
-  #  withMessage= 'expected ["lang.Generic"] but was ["void"]'
-  #)]
-  public function nullIsNotAnInstanceOfGeneric() {
-    $this->assertInstanceOf(Generic::class, null);
+  public function nullIsNotAnInstanceOfValue() {
+    $this->assertInstanceOf(\lang\Value::class, null);
   }    
 
   #[@test, @expect(
@@ -200,11 +192,6 @@ class AssertionsTest extends TestCase {
   #)]
   public function thisIsNotAnInstanceOfValue() {
     $this->assertInstanceOf(Value::class, $this);
-  }    
-
-  #[@test]
-  public function thisIsAnInstanceOfGeneric() {
-    $this->assertInstanceOf(Generic::class, $this);
   }    
 
   #[@test]

--- a/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
+++ b/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
@@ -42,7 +42,7 @@ abstract class BeforeAndAfterClassTest extends TestCase {
       public function fixture() { }
     }');
     $this->suite->runTest($t);
-    $this->assertEquals(true, $t->getClass()->getField('initialized')->get(null));
+    $this->assertEquals(true, typeof($t)->getField('initialized')->get(null));
   }
 
   #[@test]
@@ -99,7 +99,7 @@ abstract class BeforeAndAfterClassTest extends TestCase {
       public function fixture() { }
     }');
     $this->suite->runTest($t);
-    $this->assertEquals(true, $t->getClass()->getField('finalized')->get(null));
+    $this->assertEquals(true, typeof($t)->getField('finalized')->get(null));
   }
 
   #[@test]
@@ -121,7 +121,7 @@ abstract class BeforeAndAfterClassTest extends TestCase {
       public function fixture() { }
     }');
     $this->suite->runTest($t);
-    $this->assertEquals(['data', 'conn'], $t->getClass()->getField('initialized')->get(null));
+    $this->assertEquals(['data', 'conn'], typeof($t)->getField('initialized')->get(null));
   }
 
   #[@test]
@@ -143,7 +143,7 @@ abstract class BeforeAndAfterClassTest extends TestCase {
       public function fixture() { }
     }');
     $this->suite->runTest($t);
-    $this->assertEquals(['conn', 'data'], $t->getClass()->getField('finalized')->get(null));
+    $this->assertEquals(['conn', 'data'], typeof($t)->getField('finalized')->get(null));
   }
 
   #[@test]
@@ -165,6 +165,6 @@ abstract class BeforeAndAfterClassTest extends TestCase {
       public function fixture() { }
     }');
     $this->suite->runTest($t);
-    $this->assertEquals(false, $t->getClass()->getField('finalized')->get(null));
+    $this->assertEquals(false, typeof($t)->getField('finalized')->get(null));
   }
 }

--- a/src/test/php/unittest/tests/NotATest.class.php
+++ b/src/test/php/unittest/tests/NotATest.class.php
@@ -1,0 +1,5 @@
+<?php namespace unittest\tests;
+
+class NotATest {
+  
+}

--- a/src/test/php/unittest/tests/RecordActionInvocation.class.php
+++ b/src/test/php/unittest/tests/RecordActionInvocation.class.php
@@ -23,7 +23,7 @@ class RecordActionInvocation implements \unittest\TestAction {
    * @param  unittest.TestCase $t
    */
   public function beforeTest(TestCase $t) {
-    $f= $t->getClass()->getField($this->field);
+    $f= typeof($t)->getField($this->field);
     $f->set($t, array_merge($f->get($t), ['before']));
   }
 
@@ -33,7 +33,7 @@ class RecordActionInvocation implements \unittest\TestAction {
    * @param  unittest.TestCase $t
    */
   public function afterTest(TestCase $t) {
-    $f= $t->getClass()->getField($this->field);
+    $f= typeof($t)->getField($this->field);
     $f->set($t, array_merge($f->get($t), ['after']));
   }
 }

--- a/src/test/php/unittest/tests/SpecialMethodsTest.class.php
+++ b/src/test/php/unittest/tests/SpecialMethodsTest.class.php
@@ -42,7 +42,7 @@ class SpecialMethodsTest extends TestCase {
     }');
     
     try {
-      $this->suite->addTestClass($test->getClass());
+      $this->suite->addTestClass(typeof($test));
       $this->fail('Expected exception not caught', null, IllegalStateException::class);
     } catch (IllegalStateException $expected) {
       $this->assertEquals(0, $this->suite->numTests(), 'Number of test may not have changed');
@@ -51,7 +51,7 @@ class SpecialMethodsTest extends TestCase {
   
   #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
   public function setUpMethodMayNotBeATestInAddTestClass() {
-    $this->suite->addTestClass($this->setUpCase()->getClass());
+    $this->suite->addTestClass(typeof($this->setUpCase()));
   }
 
   #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
@@ -85,7 +85,7 @@ class SpecialMethodsTest extends TestCase {
 
   #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
   public function tearDownMethodMayNotBeATestInAddTestClass() {
-    $this->suite->addTestClass($this->tearDownCase()->getClass());
+    $this->suite->addTestClass(typeof($this->tearDownCase()));
   }
 
   #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
@@ -95,7 +95,7 @@ class SpecialMethodsTest extends TestCase {
 
   #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
   public function getNameMethodMayNotBeATestInAddTestClass() {
-    $this->suite->addTestClass($this->getNameCase()->getClass());
+    $this->suite->addTestClass(typeof($this->getNameCase()));
   }
 
   #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -4,7 +4,6 @@ use unittest\TestCase;
 use unittest\TestResult;
 use unittest\TestPrerequisitesNotMet;
 use lang\Error;
-use lang\Object;
 use lang\MethodNotImplementedException;
 use util\NoSuchElementException;
 use unittest\TestSuite;
@@ -90,22 +89,22 @@ class SuiteTest extends TestCase {
 
   #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function addNonTest() {
-    $this->suite->addTest(new Object());
+    $this->suite->addTest(new NotATest());
   }
 
   #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function addNonTest7() {
-    $this->suite->addTest(new Object());
+    $this->suite->addTest(new NotATest());
   }
 
   #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function runNonTest() {
-    $this->suite->runTest(new Object());
+    $this->suite->runTest(new NotATest());
   }
 
   #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function runNonTest7() {
-    $this->suite->runTest(new Object());
+    $this->suite->runTest(new NotATest());
   }
 
   #[@test, @expect(MethodNotImplementedException::class)]
@@ -170,7 +169,7 @@ class SuiteTest extends TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function addingANonTestClass() {
-    $this->suite->addTestClass(\lang\XPClass::forName('lang.Object'));
+    $this->suite->addTestClass(\lang\XPClass::forName('unittest.tests.NotATest'));
   }    
 
   #[@test]

--- a/src/test/php/unittest/tests/TestActionTest.class.php
+++ b/src/test/php/unittest/tests/TestActionTest.class.php
@@ -12,11 +12,12 @@ use unittest\PrerequisitesNotMetError;
  * Test test actions
  */
 class TestActionTest extends TestCase {
-  protected $suite;
+  protected $suite, $parent;
 
   /** @return void */
   public function setUp() {
     $this->suite= new TestSuite();
+    $this->parent= class_exists(\lang\Object::class) ? 'lang.Object' : null;  // XP9
   }
 
   #[@test]
@@ -75,7 +76,7 @@ class TestActionTest extends TestCase {
   #[@test]
   public function afterTest_is_invoked_for_succeeding_actions() {
     $actions= [];
-    ClassLoader::defineClass('unittest.tests.AllocateMemory', 'lang.Object', ['unittest.TestAction'], [
+    ClassLoader::defineClass('unittest.tests.AllocateMemory', $this->parent, ['unittest.TestAction'], [
       'beforeTest' => function(TestCase $t) use(&$actions) { $actions[]= 'allocated'; },
       'afterTest' => function(TestCase $t) use(&$actions) { $actions[]= 'freed'; }
     ]);
@@ -103,7 +104,8 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function test_action_with_arguments() {
-    ClassLoader::defineClass('unittest.tests.PlatformVerification', 'lang.Object', ['unittest.TestAction'], '{
+
+    ClassLoader::defineClass('unittest.tests.PlatformVerification', $this->parent, ['unittest.TestAction'], '{
       protected $platform;
 
       public function __construct($platform) {
@@ -151,7 +153,7 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function afterTest_can_raise_AssertionFailedErrors() {
-    ClassLoader::defineClass('unittest.tests.FailOnTearDown', 'lang.Object', ['unittest.TestAction'], '{
+    ClassLoader::defineClass('unittest.tests.FailOnTearDown', $this->parent, ['unittest.TestAction'], '{
       public function beforeTest(\unittest\TestCase $t) {
         // NOOP
       }
@@ -171,7 +173,7 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function all_afterTest_exceptions_are_chained_into_one() {
-    ClassLoader::defineClass('unittest.tests.FailOnTearDownWith', 'lang.Object', ['unittest.TestAction'], '{
+    ClassLoader::defineClass('unittest.tests.FailOnTearDownWith', $this->parent, ['unittest.TestAction'], '{
       protected $message;
 
       public function __construct($message) {

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -110,9 +110,9 @@ class UnittestRunnerTest extends TestCase {
 
   #[@test]
   public function runNonTest() {
-    $return= $this->runner->run(['lang.Object']);
+    $return= $this->runner->run(['lang.Value']);
     $this->assertEquals(2, $return);
-    $this->assertOnStream($this->err, '*** Error: Given argument is not a TestCase class (lang.XPClass<lang.Object>)');
+    $this->assertOnStream($this->err, '*** Error: Given argument is not a TestCase class (lang.XPClass<lang.Value>)');
     $this->assertEquals('', $this->out->getBytes());
   }
 


### PR DESCRIPTION
This pull request makes the unittest library compatible with XP9:

* Removes `lang.Object` references, replacing them with dedicated value objects
* Implements `lang.Value` where toString() / hashCode() / comparison are necessary
* Rewrites `$instance->getClass()` to `typeof()`.