### PR TITLE
Drop dependency on xp-framework/io-collections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.10",
-    "xp-framework/io-collections": "^8.0 | ^7.0 | ^6.5",
     "php" : ">=5.6.0"
   },
   "bin": ["bin/xp.xp-framework.unittest.test"],


### PR DESCRIPTION
This removes a circular dependency for the library currently existing:

```
xp-framework/io-collections
`- require-dev: xp-framework/unittest
   `- require: xp-framework/io-collections
```