### PR TITLE
Refactor reason field in TestWarning to contain a lang.Throwable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+dist: trusty
+
 php:
   - 5.6
   - 7.0

--- a/src/main/php/unittest/TestWarning.class.php
+++ b/src/main/php/unittest/TestWarning.class.php
@@ -22,7 +22,7 @@ class TestWarning implements TestFailure {
    */
   public function __construct(TestCase $test, array $warnings, $elapsed) {
     $this->test= $test;
-    $this->reason= $warnings;
+    $this->reason= new Warnings($warnings);
     $this->elapsed= $elapsed;
   }
 
@@ -38,17 +38,17 @@ class TestWarning implements TestFailure {
   /** @return string */
   public function toString() {
     return sprintf(
-      "%s(test= %s, time= %.3f seconds) {\n  %s\n }",
+      "%s(test= %s, time= %.3f seconds) {\n  %s\n}",
       nameof($this),
       $this->test->getName(true),
       $this->elapsed,
-      \xp::stringOf($this->reason, '  ')
+      str_replace("\n", "\n  ", $this->reason->compoundMessage())
     );
   }
 
   /** @return string */
   public function hashCode() {
-    return Objects::hashOf([null => $this->test] + $this->reason);
+    return Objects::hashOf([null => $this->test] + $this->reason->all());
   }
 
   /**

--- a/src/main/php/unittest/Warnings.class.php
+++ b/src/main/php/unittest/Warnings.class.php
@@ -1,0 +1,26 @@
+<?php namespace unittest;
+
+class Warnings extends \lang\XPException {
+  private $list;
+
+  /** @param string[] $lit */
+  public function __construct($list) {
+    $this->list= $list;    
+    parent::__construct(sizeof($list).' warning(s) raised');
+  }
+
+  /** @return string[] */
+  public function all() { return $this->list; }
+
+  /** @return string */
+  public function compoundMessage() {
+    $s= nameof($this).'('.sizeof($this->list).')';
+    if (empty($this->list)) return $s;
+
+    $s.= "@{\n";
+    foreach ($this->list as $warning) {
+      $s.= '  '.$warning."\n";
+    }
+    return $s.'}';
+  }
+}

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -339,7 +339,7 @@ class SuiteTest extends TestCase {
     ]);
     $this->assertEquals(
       [sprintf('"Test error" in ::trigger_error() (SuiteTest.class.php, line %d, occured once)', __LINE__ - 3)],
-      $this->suite->runTest($test)->failed[$test->hashCode()]->reason
+      $this->suite->runTest($test)->failed[$test->hashCode()]->reason->all()
     );
   }
 
@@ -386,7 +386,7 @@ class SuiteTest extends TestCase {
     ]);
     $this->assertEquals(
       [sprintf('"Test error" in ::trigger_error() (SuiteTest.class.php, line %d, occured once)', __LINE__ - 5)],
-      $this->suite->runTest($test)->failed[$test->hashCode()]->reason
+      $this->suite->runTest($test)->failed[$test->hashCode()]->reason->all()
     );
   }
   

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -91,8 +91,13 @@ class TestOutcomeTest extends \unittest\TestCase {
   #[@test, @values('fixtures')]
   public function string_representation_of_TestWarning($test, $variant) {
     $this->assertStringRepresentation(
-      "unittest.TestWarning(test= %s, time= 0.000 seconds) {\n  [\"Could not open file\"]\n }",
-      new TestWarning($test, ['Could not open file'], 0.0), $variant
+      "unittest.TestWarning(test= %s, time= 0.000 seconds) {\n".
+      "  unittest.Warnings(1)@{\n".
+      "    Could not open file\n".
+      "  }\n".
+      "}",
+      new TestWarning($test, ['Could not open file'], 0.0),
+      $variant
     );
   }
 }


### PR DESCRIPTION
Fixes  a method call on array in case `-s fail` is given and warnings are the reason for the first failing test. There would be an easier fix right inside the StopListener class, but making TestWarnings consistent with the other error outcomes seemed the better path forward.