### PR TITLE
Refactor test runner

### DIFF
--- a/src/main/php/unittest/AssertionFailedError.class.php
+++ b/src/main/php/unittest/AssertionFailedError.class.php
@@ -5,7 +5,7 @@
  *
  * @see  xp://unittest.AssertionFailedMessage
  */
-class AssertionFailedError extends \lang\XPException {
+class AssertionFailedError extends TestAborted {
 
   /**
    * Constructor
@@ -25,6 +25,12 @@ class AssertionFailedError extends \lang\XPException {
       $element->args= null;
     }
   }
+
+  /** @return string */
+  public function type() { return 'testFailed'; }
+
+  /** @return string */
+  public function outcome() { return TestAssertionFailed::class; }
 
   /**
    * Return compound message of this exception.

--- a/src/main/php/unittest/AssertionFailedError.class.php
+++ b/src/main/php/unittest/AssertionFailedError.class.php
@@ -1,5 +1,7 @@
 <?php namespace unittest;
 
+use util\profiling\Timer;
+
 /**
  * Indicates an assertion failed
  *
@@ -29,8 +31,10 @@ class AssertionFailedError extends TestAborted {
   /** @return string */
   public function type() { return 'testFailed'; }
 
-  /** @return string */
-  public function outcome() { return TestAssertionFailed::class; }
+  /** @return unittest.TestOutcome */
+  public function outcome(TestCase $test, Timer $timer) {
+    return new TestAssertionFailed($test, $this, $timer->elapsedTime());
+  }
 
   /**
    * Return compound message of this exception.

--- a/src/main/php/unittest/AssertionFailedError.class.php
+++ b/src/main/php/unittest/AssertionFailedError.class.php
@@ -12,7 +12,7 @@ class AssertionFailedError extends TestAborted {
   /**
    * Constructor
    *
-   * @param   var message
+   * @param  string|unittest.AssertionFailedMessage $message
    */
   public function __construct($message) {
     if ($message instanceof AssertionFailedMessage) {

--- a/src/main/php/unittest/DidNotCatch.class.php
+++ b/src/main/php/unittest/DidNotCatch.class.php
@@ -1,0 +1,30 @@
+<?php namespace unittest;
+
+class DidNotCatch implements AssertionFailedMessage {
+  private $expected, $thrown;
+
+  /**
+   * Constructor
+   *
+   * @param   lang.XPClass $expected
+   * @param   lang.Throwable $thrown
+   */
+  public function __construct($expected, $thrown= null) {
+    $this->expected= $expected;
+    $this->thrown= $thrown;
+  }
+
+
+  /**
+   * Return formatted message
+   *
+   * @return  string
+   */
+  public function format() {
+    if ($this->thrown) {
+      return 'Caught '.$this->thrown->compoundMessage().' instead of expected '.$this->expected->getName();
+    } else {
+      return 'Expected '.$this->expected->getName().' not caught';
+    }
+  }
+}

--- a/src/main/php/unittest/Errors.class.php
+++ b/src/main/php/unittest/Errors.class.php
@@ -2,15 +2,15 @@
 
 abstract class Errors {
 
-  /** @return bool */
-  public static function present() { return !empty(\xp::$errors); }
+  /** @return void */
+  public static function clear() { \xp::gc(); }
   
   /**
    * Returns all errors in registry
    *
    * @return string[]
    */
-  public static function all() {
+  public static function raised() {
     $w= [];
     foreach (\xp::$errors as $file => $lookup) {
       foreach ($lookup as $line => $messages) {

--- a/src/main/php/unittest/Errors.class.php
+++ b/src/main/php/unittest/Errors.class.php
@@ -1,0 +1,32 @@
+<?php namespace unittest;
+
+abstract class Errors {
+
+  /** @return bool */
+  public static function present() { return !empty(\xp::$errors); }
+  
+  /**
+   * Returns all errors in registry
+   *
+   * @return string[]
+   */
+  public static function all() {
+    $w= [];
+    foreach (\xp::$errors as $file => $lookup) {
+      foreach ($lookup as $line => $messages) {
+        foreach ($messages as $message => $detail) {
+          $w[]= sprintf(
+            '"%s" in %s::%s() (%s, line %d, occured %s)',
+            $message,
+            $detail['class'],
+            $detail['method'],
+            basename($file),
+            $line,
+            1 === $detail['cnt'] ? 'once' : $detail['cnt'].' times'
+          );
+        }
+      }
+    }
+    return $w;
+  }
+}

--- a/src/main/php/unittest/ExpectedMessageDiffers.class.php
+++ b/src/main/php/unittest/ExpectedMessageDiffers.class.php
@@ -1,0 +1,31 @@
+<?php namespace unittest;
+
+class ExpectedMessageDiffers implements AssertionFailedMessage {
+  private $expected, $thrown;
+
+  /**
+   * Constructor
+   *
+   * @param   string $expected
+   * @param   lang.Throwable $thrown
+   */
+  public function __construct($expected, $thrown) {
+    $this->expected= $expected;
+    $this->thrown= $thrown;
+  }
+
+
+  /**
+   * Return formatted message
+   *
+   * @return  string
+   */
+  public function format() {
+    return sprintf(
+      'Expected %s\'s message "%s" differs from expected %s',
+      nameof($this->thrown),
+      $this->thrown->getMessage(),
+      $this->expected
+    );
+  }
+}

--- a/src/main/php/unittest/IgnoredBecause.class.php
+++ b/src/main/php/unittest/IgnoredBecause.class.php
@@ -3,7 +3,7 @@
 /**
  * Indicates an `@ignore` annotation was present
  */
-class IgnoredBecause extends \lang\XPException {
+class IgnoredBecause extends TestAborted {
     
   /**
    * Constructor
@@ -13,6 +13,12 @@ class IgnoredBecause extends \lang\XPException {
   public function __construct($value) {
     parent::__construct($value ? (string)$value : 'n/a');
   }
+
+  /** @return string */
+  public function type() { return 'testSkipped'; }
+
+  /** @return string */
+  public function outcome() { return TestNotRun::class; }
 
   /**
    * Return compound message of this exception.

--- a/src/main/php/unittest/IgnoredBecause.class.php
+++ b/src/main/php/unittest/IgnoredBecause.class.php
@@ -1,5 +1,7 @@
 <?php namespace unittest;
 
+use util\profiling\Timer;
+
 /**
  * Indicates an `@ignore` annotation was present
  */
@@ -17,8 +19,10 @@ class IgnoredBecause extends TestAborted {
   /** @return string */
   public function type() { return 'testSkipped'; }
 
-  /** @return string */
-  public function outcome() { return TestNotRun::class; }
+  /** @return unittest.TestOutcome */
+  public function outcome(TestCase $test, Timer $timer) {
+    return new TestNotRun($test, $this, $timer->elapsedTime());
+  }
 
   /**
    * Return compound message of this exception.

--- a/src/main/php/unittest/PrerequisitesNotMetError.class.php
+++ b/src/main/php/unittest/PrerequisitesNotMetError.class.php
@@ -2,6 +2,7 @@
 
 use lang\Throwable;
 use util\Objects;
+use util\profiling\Timer;
 
 /**
  * Indicates prerequisites have not been met
@@ -26,8 +27,10 @@ class PrerequisitesNotMetError extends TestAborted {
   /** @return string */
   public function type() { return 'testSkipped'; }
 
-  /** @return string */
-  public function outcome() { return TestPrerequisitesNotMet::class; }
+  /** @return unittest.TestOutcome */
+  public function outcome(TestCase $test, Timer $timer) {
+    return new TestPrerequisitesNotMet($test, $this, $timer->elapsedTime());
+  }
 
   /**
    * Return compound message of this exception.

--- a/src/main/php/unittest/PrerequisitesNotMetError.class.php
+++ b/src/main/php/unittest/PrerequisitesNotMetError.class.php
@@ -1,37 +1,45 @@
 <?php namespace unittest;
 
 use lang\Throwable;
+use util\Objects;
 
 /**
  * Indicates prerequisites have not been met
  *
+ * @see  xp://unittest.TestPrerequisitesNotMet
  */
-class PrerequisitesNotMetError extends \lang\XPException {
+class PrerequisitesNotMetError extends TestAborted {
   public $prerequisites= [];
     
   /**
    * Constructor
    *
-   * @param   string message
-   * @param   lang.Throwable cause 
-   * @param   var[] prerequisites default []
+   * @param  string $message
+   * @param  lang.Throwable $cause 
+   * @param  var[] $prerequisites default []
    */
   public function __construct($message, Throwable $cause= null, $prerequisites= []) {
     parent::__construct($message, $cause);
     $this->prerequisites= (array)$prerequisites;
   }
 
+  /** @return string */
+  public function type() { return 'testSkipped'; }
+
+  /** @return string */
+  public function outcome() { return TestPrerequisitesNotMet::class; }
+
   /**
    * Return compound message of this exception.
    *
-   * @return  string
+   * @return string
    */
   public function compoundMessage() {
     return sprintf(
-      '%s (%s) { prerequisites: [%s] }',
+      '%s (%s) { prerequisites: %s }',
       nameof($this),
       $this->message,
-      implode(', ', array_map(['xp', 'stringOf'], $this->prerequisites))
+      Objects::stringOf($this->prerequisites)
     );
   }
 }

--- a/src/main/php/unittest/TestAborted.class.php
+++ b/src/main/php/unittest/TestAborted.class.php
@@ -1,0 +1,23 @@
+<?php namespace unittest;
+
+/**
+ * Indicates a test run was aborted
+ */
+abstract class TestAborted extends \lang\XPException {
+
+  /**
+   * Returns the type which is passed to the listeners
+   *
+   * @see    xp://unittest.TestSuite#notifyListeners
+   * @return string
+   */ 
+  public abstract function type();   
+
+  /**
+   * Returns the outcome class
+   *
+   * @return string
+   */ 
+  public abstract function outcome();   
+
+}

--- a/src/main/php/unittest/TestAborted.class.php
+++ b/src/main/php/unittest/TestAborted.class.php
@@ -1,5 +1,7 @@
 <?php namespace unittest;
 
+use util\profiling\Timer;
+
 /**
  * Indicates a test run was aborted
  */
@@ -16,8 +18,10 @@ abstract class TestAborted extends \lang\XPException {
   /**
    * Returns the outcome class
    *
-   * @return string
+   * @param  unittest.TestCase $test
+   * @param  util.profiling.Timer $timer
+   * @return unittest.TestOutcome
    */ 
-  public abstract function outcome();   
+  public abstract function outcome(TestCase $test, Timer $timer);
 
 }

--- a/src/main/php/unittest/TestAssertionFailed.class.php
+++ b/src/main/php/unittest/TestAssertionFailed.class.php
@@ -17,12 +17,12 @@ class TestAssertionFailed implements TestFailure {
    * Constructor
    *
    * @param   unittest.TestCase test
-   * @param   unittest.AssertionFailedError reason
+   * @param   unittest.AssertionFailedError|unittest.AssertionFailedMessage|string reason
    * @param   float elapsed
    */
-  public function __construct(TestCase $test, AssertionFailedError $reason, $elapsed) {
+  public function __construct(TestCase $test, $reason, $elapsed) {
     $this->test= $test;
-    $this->reason= $reason;
+    $this->reason= $reason instanceof AssertionFailedError ? $reason : new AssertionFailedError($reason);
     $this->elapsed= $elapsed;
   }
 

--- a/src/main/php/unittest/TestAssertionFailed.class.php
+++ b/src/main/php/unittest/TestAssertionFailed.class.php
@@ -1,67 +1,25 @@
 <?php namespace unittest;
 
-use util\Objects;
-
 /**
  * Indicates a test failed
  *
  * @see   xp://unittest.TestFailure
  */
-class TestAssertionFailed implements TestFailure {
-  public
-    $reason   = null,
-    $test     = null,
-    $elapsed  = 0.0;
-    
+class TestAssertionFailed extends TestFailure {
+
   /**
    * Constructor
    *
-   * @param   unittest.TestCase test
-   * @param   unittest.AssertionFailedError|unittest.AssertionFailedMessage|string reason
-   * @param   float elapsed
+   * @param  unittest.TestCase $test
+   * @param  unittest.AssertionFailedError|unittest.AssertionFailedMessage|string $reason
+   * @param  double $elapsed
    */
   public function __construct(TestCase $test, $reason, $elapsed) {
-    $this->test= $test;
+    parent::__construct($test, $elapsed);
     $this->reason= $reason instanceof AssertionFailedError ? $reason : new AssertionFailedError($reason);
-    $this->elapsed= $elapsed;
-  }
-
-  /**
-   * Returns elapsed time
-   *
-   * @return  float
-   */
-  public function elapsed() {
-    return $this->elapsed;
-  }
-
-  /**
-   * Return a string representation of this class
-   *
-   * @return  string
-   */
-  public function toString() {
-    return sprintf(
-      "%s(test= %s, time= %.3f seconds) {\n  %s\n }",
-      nameof($this),
-      $this->test->getName(true),
-      $this->elapsed,
-      \xp::stringOf($this->reason, '  ')
-    );
   }
 
   /** @return string */
-  public function hashCode() {
-    return Objects::hashOf([$this->test, $this->reason]);
-  }
+  protected function formatReason() { return $this->reason->toString(); }
 
-  /**
-   * Compares this test outcome to a given value
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
-  }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -41,6 +41,9 @@ class TestClass extends TestGroup {
     $this->arguments= (array)$arguments;
   }
 
+  /** @return lang.XPClass */
+  public function type() { return $this->class; }
+
   /** @return int */
   public function numTests() { return sizeof($this->testMethods); }
 

--- a/src/main/php/unittest/TestError.class.php
+++ b/src/main/php/unittest/TestError.class.php
@@ -1,67 +1,26 @@
 <?php namespace unittest;
 
-use util\Objects;
+use lang\Throwable;
 
 /**
  * Indicates a test failed
  *
  * @see   xp://unittest.TestFailure
  */
-class TestError implements TestFailure {
-  public
-    $reason   = null,
-    $test     = null,
-    $elapsed  = 0.0;
-    
+class TestError extends TestFailure {
+
   /**
    * Constructor
    *
-   * @param   unittest.TestCase test
-   * @param   lang.Throwable reason
-   * @param   float elapsed
+   * @param  unittest.TestCase $test
+   * @param  lang.Throwable $reason
+   * @param  double $elapsed
    */
-  public function __construct(TestCase $test, \lang\Throwable $reason, $elapsed) {
-    $this->test= $test;
+  public function __construct(TestCase $test, Throwable $reason, $elapsed) {
+    parent::__construct($test, $elapsed);
     $this->reason= $reason;
-    $this->elapsed= $elapsed;
-  }
-
-  /**
-   * Returns elapsed time
-   *
-   * @return  float
-   */
-  public function elapsed() {
-    return $this->elapsed;
-  }
-
-  /**
-   * Return a string representation of this class
-   *
-   * @return  string
-   */
-  public function toString() {
-    return sprintf(
-      "%s(test= %s, time= %.3f seconds) {\n  %s\n }",
-      nameof($this),
-      $this->test->getName(true),
-      $this->elapsed,
-      str_replace("\n", "\n  ", $this->reason->toString())
-    );
   }
 
   /** @return string */
-  public function hashCode() {
-    return Objects::hashOf([$this->test, $this->reason]);
-  }
-
-  /**
-   * Compares this test outcome to a given value
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
-  }
+  protected function formatReason() { return $this->reason->toString(); }
 }

--- a/src/main/php/unittest/TestExpectationMet.class.php
+++ b/src/main/php/unittest/TestExpectationMet.class.php
@@ -1,61 +1,10 @@
 <?php namespace unittest;
 
 /**
- * Indicates a test was successful
+ * Indicates a test's expectation was met
  *
  * @see   xp://unittest.TestSuccess
  */
-class TestExpectationMet implements TestSuccess {
-  public
-    $test     = null,
-    $elapsed  = 0.0;
+class TestExpectationMet extends TestSuccess {
     
-  /**
-   * Constructor
-   *
-   * @param   unittest.TestCase test
-   * @param   float elapsed
-   */
-  public function __construct(TestCase $test, $elapsed) {
-    $this->test= $test;
-    $this->elapsed= $elapsed;
-  }
-
-  /**
-   * Returns elapsed time
-   *
-   * @return  float
-   */
-  public function elapsed() {
-    return $this->elapsed;
-  }
-  
-  /**
-   * Return a string representation of this class
-   *
-   * @return  string
-   */
-  public function toString() {
-    return sprintf(
-      '%s(test= %s, time= %.3f seconds)',
-      nameof($this),
-      $this->test->getName(true),
-      $this->elapsed
-    );
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return $this->test->hashCode();
-  }
-
-  /**
-   * Compares this test outcome to a given value
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? $this->test->compareTo($value->test) : 1;
-  }
 }

--- a/src/main/php/unittest/TestFailure.class.php
+++ b/src/main/php/unittest/TestFailure.class.php
@@ -1,11 +1,39 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Indicates a test failed
  *
  * @see   xp://unittest.TestAssertionFailed
  * @see   xp://unittest.TestError
  */
-interface TestFailure extends TestOutcome {
-  
+abstract class TestFailure extends TestOutcome {
+  public $reason;
+
+  /** @return string */
+  protected abstract function formatReason();
+
+  /** @return string */
+  public function toString() {
+    return parent::toString()." {\n  ".str_replace("\n", "\n  ", $this->formatReason())."\n}";
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->test, $this->elapsed, $this->reason]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->test, $this->elapsed, $this->reason], [$value->test, $this->elapsed, $value->reason])
+      : 1
+    ;
+  }
 }

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -2,6 +2,7 @@
 
 use lang\XPClass;
 use lang\IllegalStateException;
+use lang\reflect\TargetInvocationException;
 
 abstract class TestGroup {
   protected static $base;
@@ -23,6 +24,69 @@ abstract class TestGroup {
       $method->getName(),
       $method->getDeclaringClass()->getName()
     ));
+  }
+
+  /**
+   * Returns TestClassActions for a given class
+   *
+   * @param  lang.XPClass $class
+   * @return iterable
+   */
+  private function actionsFor($class) {
+    if ($class->hasAnnotation('action')) {
+      $action= $class->getAnnotation('action');
+      if (is_array($action)) {
+        foreach ($action as $a) {
+          if ($a instanceof TestClassAction) yield $a;
+        }
+      } else {
+        if ($action instanceof TestClassAction) yield $action;
+      }
+    }
+  }
+
+  /**
+   * Runs actions before this group
+   *
+   * @return void
+   * @throws unittest.PrerequisitesNotMetError
+   */
+  public function before() {
+    $class= $this->type();
+    foreach ($class->getMethods() as $m) {
+      if (!$m->hasAnnotation('beforeClass')) continue;
+      try {
+        $m->invoke(null, []);
+      } catch (TargetInvocationException $e) {
+        $cause= $e->getCause();
+        if ($cause instanceof PrerequisitesNotMetError) {
+          throw $cause;
+        } else {
+          throw new PrerequisitesNotMetError('Exception in beforeClass method '.$m->getName(), $cause);
+        }
+      }
+    }
+    foreach ($this->actionsFor($class) as $action) {
+      $action->beforeTestClass($class);
+    }
+  }
+
+  /**
+   * Runs actions after this group
+   *
+   * @return void
+   */
+  public function after() {
+    $class= $this->type();
+    foreach ($this->actionsFor($class) as $action) {
+      $action->afterTestClass($class);
+    }
+    foreach ($class->getMethods() as $m) {
+      if (!$m->hasAnnotation('afterClass')) continue;
+      try {
+        $m->invoke(null, []);
+      } catch (TargetInvocationException $ignored) { }
+    }
   }
 
   /** @return lang.XPClass */

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -25,6 +25,9 @@ abstract class TestGroup {
     ));
   }
 
+  /** @return lang.XPClass */
+  public abstract function type();
+
   /** @return int */
   public abstract function numTests();
 

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -27,11 +27,12 @@ class TestInstance extends TestGroup {
     $this->instance= $instance;
   }
 
+  /** @return lang.XPClass */
+  public function type() { return typeof($this->instance); }
+
   /** @return int */
   public function numTests() { return 1; }
 
-  /** @return php.Generator */
-  public function tests() {
-    yield $this->instance;
-  }
+  /** @return iterable */
+  public function tests() { yield $this->instance; }
 }

--- a/src/main/php/unittest/TestNotRun.class.php
+++ b/src/main/php/unittest/TestNotRun.class.php
@@ -1,63 +1,21 @@
 <?php namespace unittest;
 
-use util\Objects;
-
 /**
  * Indicates a test was ignored
  *
  * @see   xp://unittest.TestSkipped
  */
-class TestNotRun implements TestSkipped {
-  public
-    $reason   = '',
-    $test     = null;
-    
+class TestNotRun extends TestSkipped {
+
   /**
    * Constructor
    *
-   * @param   unittest.TestCase test
-   * @param   string reason
+   * @param  unittest.TestCase $test
+   * @param  string $reason
+   * @param  double $elapsed
    */
   public function __construct(TestCase $test, $reason) {
-    $this->test= $test;
+    parent::__construct($test, 0.0);
     $this->reason= $reason;
-  }
-
-  /**
-   * Returns elapsed time
-   *
-   * @return  float
-   */
-  public function elapsed() {
-    return 0.0;
-  }
-
-  /**
-   * Return a string representation of this class
-   *
-   * @return  string
-   */
-  public function toString() {
-    return sprintf(
-      "%s(test= %s, time= 0.000 seconds) {\n  %s\n }",
-      nameof($this),
-      $this->test->getName(true),
-      Objects::stringOf($this->reason, '  ')
-    );
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return Objects::hashOf([$this->test, $this->reason]);
-  }
-
-  /**
-   * Compares this test outcome to a given value
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/TestOutcome.class.php
+++ b/src/main/php/unittest/TestOutcome.class.php
@@ -1,16 +1,46 @@
 <?php namespace unittest;
 
-/**
- * Outcome from a test
- *
- */
-interface TestOutcome extends \lang\Value {
+/** Outcome from a test */
+abstract class TestOutcome implements \lang\Value {
+  public $test, $elapsed;
 
   /**
-   * Returns elapsed time
+   * Constructor
    *
-   * @return  float
+   * @param  unittest.TestCase test
+   * @param  double elapsed
    */
-  public function elapsed();
+  public function __construct(TestCase $test, $elapsed) {
+    $this->test= $test;
+    $this->elapsed= $elapsed;
+  }
 
+  /** @return unittest.TestCase */
+  public function test() { return $this->test; }
+
+  /** @return double */
+  public function elapsed() { return $this->elapsed; }
+
+  /** @return string */
+  public function toString() {
+    return sprintf('%s(test= %s, time= %.3f seconds)', nameof($this), $this->test->getName(true), $this->elapsed);
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return 'O'.$this->test->hashCode();
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare(([$this->test, $this->elapsed]), [$value->test, $value->elapsed])
+      : 1
+    ;
+  }
 }

--- a/src/main/php/unittest/TestPrerequisitesNotMet.class.php
+++ b/src/main/php/unittest/TestPrerequisitesNotMet.class.php
@@ -1,67 +1,21 @@
 <?php namespace unittest;
 
-use util\Objects;
-
 /**
  * Indicates a test was skipped
  *
  * @see      xp://unittest.TestSkipped
  */
-class TestPrerequisitesNotMet implements TestSkipped {
-  public
-    $reason   = null,
-    $test     = null,
-    $elapsed  = 0.0;
+class TestPrerequisitesNotMet extends TestSkipped {
     
   /**
    * Constructor
    *
-   * @param   unittest.TestCase $test
-   * @param   unittest.PrerequisitesNotMetError $reason
-   * @param   float $elapsed
+   * @param  unittest.TestCase $test
+   * @param  unittest.PrerequisitesNotMetError $reason
+   * @param  double $elapsed
    */
   public function __construct(TestCase $test, PrerequisitesNotMetError $reason, $elapsed) {
-    $this->test= $test;
+    parent::__construct($test, $elapsed);
     $this->reason= $reason;
-    $this->elapsed= $elapsed;
-  }
-
-  /**
-   * Returns elapsed time
-   *
-   * @return  float
-   */
-  public function elapsed() {
-    return $this->elapsed;
-  }
-
-  /**
-   * Return a string representation of this class
-   *
-   * @return  string
-   */
-  public function toString() {
-    return sprintf(
-      "%s(test= %s, time= %.3f seconds) {\n  %s\n }",
-      nameof($this),
-      $this->test->getName(true),
-      $this->elapsed,
-      \xp::stringOf($this->reason, '  ')
-    );
-  }
-
-  /** @return string */
-  public function hashCode() {
-    return Objects::hashOf([$this->test, $this->reason]);
-  }
-
-  /**
-   * Compares this test outcome to a given value
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
   }
 }

--- a/src/main/php/unittest/TestResult.class.php
+++ b/src/main/php/unittest/TestResult.class.php
@@ -12,58 +12,25 @@ class TestResult implements \lang\Value {
     $succeeded    = [],
     $failed       = [],
     $skipped      = [];
-    
+
   /**
-   * Set outcome for a given test
+   * Record outcome for a given test
    *
-   * @param   unittest.TestCase test
-   * @param   unittest.TestOutcome outcome
-   * @return  unittest.TestOutcome the given outcome
+   * @param  unittest.TestOutcome $outcome
+   * @return unittest.TestOutcome the given outcome
    */
-  public function set(TestCase $test, TestOutcome $outcome) {
+  public function record(TestOutcome $outcome) {
+    $key= $outcome->test()->hashCode();
     if ($outcome instanceof TestSuccess) {
-      $this->succeeded[$test->hashCode()]= $outcome;
+      $this->succeeded[$key]= $outcome;
     } else if ($outcome instanceof TestSkipped) {
-      $this->skipped[$test->hashCode()]= $outcome;
+      $this->skipped[$key]= $outcome;
     } else if ($outcome instanceof TestFailure) {
-      $this->failed[$test->hashCode()]= $outcome;
+      $this->failed[$key]= $outcome;
     }
     return $outcome;
   }
-  
-  /**
-   * Mark a test as succeeded
-   *
-   * @param   unittest.TestCase test
-   * @param   float elapsed
-   */
-  public function setSucceeded($test, $elapsed) {
-    return $this->succeeded[$test->hashCode()]= new TestExpectationMet($test, $elapsed);
-  }
-  
-  /**
-   * Mark a test as failed
-   *
-   * @param   unittest.TestCase test
-   * @param   var reason
-   * @param   float elapsed
-   */
-  public function setFailed($test, $reason, $elapsed) {
-    return $this->failed[$test->hashCode()]= new TestAssertionFailed($test, $reason, $elapsed);
-  }
 
-  /**
-   * Mark a test as been skipped
-   *
-   * @param   unittest.TestCase test
-   * @param   var reason
-   * @param   float elapsed
-   * @return  unittest.TestSkipped s
-   */
-  public function setSkipped($test, $reason, $elapsed) {
-    return $this->skipped[$test->hashCode()]= new TestPrerequisitesNotMet($test, $reason, $elapsed);
-  }
-  
   /**
    * Returns the outcome of a specific test
    *
@@ -76,6 +43,54 @@ class TestResult implements \lang\Value {
       if (isset($lookup[$key])) return $lookup[$key];
     }
     return null;
+  }
+
+  /**
+   * Set outcome for a given test
+   *
+   * @deprecated Use record() instead
+   * @param   unittest.TestCase test
+   * @param   unittest.TestOutcome outcome
+   * @return  unittest.TestOutcome the given outcome
+   */
+  public function set(TestCase $test, TestOutcome $outcome) {
+    return $this->record($outcome);
+  }
+  
+  /**
+   * Mark a test as succeeded
+   *
+   * @deprecated Use record() instead
+   * @param   unittest.TestCase test
+   * @param   float elapsed
+   */
+  public function setSucceeded($test, $elapsed) {
+    return $this->succeeded[$test->hashCode()]= new TestExpectationMet($test, $elapsed);
+  }
+  
+  /**
+   * Mark a test as failed
+   *
+   * @deprecated Use record() instead
+   * @param   unittest.TestCase test
+   * @param   var reason
+   * @param   float elapsed
+   */
+  public function setFailed($test, $reason, $elapsed) {
+    return $this->failed[$test->hashCode()]= new TestAssertionFailed($test, $reason, $elapsed);
+  }
+
+  /**
+   * Mark a test as been skipped
+   *
+   * @deprecated Use record() instead
+   * @param   unittest.TestCase test
+   * @param   var reason
+   * @param   float elapsed
+   * @return  unittest.TestSkipped s
+   */
+  public function setSkipped($test, $reason, $elapsed) {
+    return $this->skipped[$test->hashCode()]= new TestPrerequisitesNotMet($test, $reason, $elapsed);
   }
 
   /**

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -1,0 +1,351 @@
+<?php namespace unittest;
+
+use lang\reflect\TargetInvocationException;
+use lang\Throwable;
+use lang\XPClass;
+use util\profiling\Timer;
+
+class TestRun {
+  private $result, $listeners;
+
+  public function __construct($result, $listeners) {
+    $this->result= $result;
+    $this->listeners= $listeners;
+  }
+
+  /**
+   * Notify listeners
+   *
+   * @param  string $method
+   * @param  var[] $args
+   * @return void
+   */
+  public function notify($method, $args) {
+    foreach ($this->listeners as $l) {
+      $l->{$method}(...$args);
+    }
+  }
+
+  /**
+   * Call beforeClass methods if present. If any of them throws an exception,
+   * mark all tests in this class as skipped and continue with tests from
+   * other classes (if available)
+   *
+   * @param  lang.XPClass class
+   * @return void
+   */
+  protected function beforeClass($class) {
+    foreach ($class->getMethods() as $m) {
+      if (!$m->hasAnnotation('beforeClass')) continue;
+      try {
+        $m->invoke(null, []);
+      } catch (TargetInvocationException $e) {
+        $cause= $e->getCause();
+        if ($cause instanceof PrerequisitesNotMetError) {
+          throw $cause;
+        } else {
+          throw new PrerequisitesNotMetError('Exception in beforeClass method '.$m->getName(), $cause);
+        }
+      }
+    }
+    foreach ($this->actionsFor($class, TestClassAction::class) as $action) {
+      $action->beforeTestClass($class);
+    }
+  }
+  
+  /**
+   * Call afterClass methods of the last test's class. Ignore any 
+   * exceptions thrown from these methods.
+   *
+   * @param  lang.XPClass class
+   * @return void
+   */
+  protected function afterClass($class) {
+    foreach ($this->actionsFor($class, TestClassAction::class) as $action) {
+      $action->afterTestClass($class);
+    }
+    foreach ($class->getMethods() as $m) {
+      if (!$m->hasAnnotation('afterClass')) continue;
+      try {
+        $m->invoke(null, []);
+      } catch (TargetInvocationException $ignored) { }
+    }
+  }
+
+ /**
+   * Returns values
+   *
+   * @param  unittest.TestCase test
+   * @param  var annotation
+   * @return var values a traversable structure
+   */
+  protected function valuesFor($test, $annotation) {
+    if (!is_array($annotation)) {               // values("source")
+      $source= $annotation;
+      $args= [];
+    } else if (isset($annotation['source'])) {  // values(source= "src" [, args= ...])
+      $source= $annotation['source'];
+      $args= isset($annotation['args']) ? $annotation['args'] : [];
+    } else {                                    // values([1, 2, 3])
+      return $annotation;
+    }
+
+    // Route "ClassName::methodName" -> static method of the given class,
+    // "self::method" -> static method of the test class, and "method" 
+    // -> the run test's instance method
+    if (false === ($p= strpos($source, '::'))) {
+      return typeof($test)->getMethod($source)->setAccessible(true)->invoke($test, $args);
+    }
+
+    $ref= substr($source, 0, $p);
+    if ('self' === $ref) {
+      $class= typeof($test);
+    } else if (strstr($ref, '.')) {
+      $class= XPClass::forName($ref);
+    } else {
+      $class= new XPClass($ref);
+    }
+    return $class->getMethod(substr($source, $p+ 2))->invoke(null, $args);
+  }
+
+  /**
+   * Returns values
+   *
+   * @param  var annotatable
+   * @param  string impl The interface which must've been implemented
+   * @return var[]
+   */
+  protected function actionsFor($annotatable, $impl) {
+    $r= [];
+    if ($annotatable->hasAnnotation('action')) {
+      $action= $annotatable->getAnnotation('action');
+      $type= XPClass::forName($impl);
+      if (is_array($action)) {
+        foreach ($action as $a) {
+          if ($type->isInstance($a)) $r[]= $a;
+        }
+      } else {
+        if ($type->isInstance($action)) $r[]= $action;
+      }
+    }
+    return $r;
+  }
+
+  /**
+   * Invoke a block, wrap PHP5 and PHP7 native base exceptions in lang.Error
+   *
+   * @param  function(?): void $block
+   * @param  var $arg
+   * @return void
+   */
+  private function invoke($block, $arg) {
+    try {
+      $block($arg);
+    } catch (Throwable $e) {
+      throw $e;
+    } catch (\Exception $e) {
+      throw Throwable::wrap($e);
+    } catch (\Throwable $e) {
+      throw Throwable::wrap($e);
+    }
+  }
+
+  /**
+   * Record outcome, notifying listeners
+   *
+   * @param  string $type
+   * @param  unittest.TestOutcome $result
+   * @return void
+   */
+  protected function record($type, $outcome) {
+    $this->notify($type, [$this->result->record($outcome)]);
+    Errors::clear();
+  }
+
+  /**
+   * Run a test case.
+   *
+   * @param  unittest.TestCase $test
+   * @param  unittest.TestResult $result
+   * @return void
+   */
+  protected function run($test) {
+    $class= typeof($test);
+    $method= $class->getMethod($test->name);
+    $this->notify('testStarted', [$test]);
+    
+    // Check for @ignore
+    if ($method->hasAnnotation('ignore')) {
+      $this->record('testNotRun', new TestNotRun($test, new IgnoredBecause($method->getAnnotation('ignore'))));
+      return;
+    }
+
+    // Check for @expect
+    $expected= null;
+    if ($method->hasAnnotation('expect', 'class')) {
+      $message= $method->getAnnotation('expect', 'withMessage');
+      if ('' === $message || '/' === $message{0}) {
+        $pattern= $message;
+      } else {
+        $pattern= '/'.preg_quote($message, '/').'/';
+      }
+      $expected= [XPClass::forName($method->getAnnotation('expect', 'class')), $pattern];
+    } else if ($method->hasAnnotation('expect')) {
+      $expected= [XPClass::forName($method->getAnnotation('expect')), null];
+    }
+    
+    // Check for @limit
+    $eta= 0;
+    if ($method->hasAnnotation('limit')) {
+      $eta= $method->getAnnotation('limit', 'time');
+    }
+
+    // Check for @values
+    if ($method->hasAnnotation('values')) {
+      $annotation= $method->getAnnotation('values');
+      $variation= true;
+      $values= $this->valuesFor($test, $annotation);
+    } else {
+      $variation= false;
+      $values= [[]];
+    }
+
+    // Check for @actions
+    $actions= array_merge(
+      $this->actionsFor($class, TestAction::class),
+      $this->actionsFor($method, TestAction::class)
+    );
+
+    $timer= new Timer();
+    Errors::clear();
+    foreach ($values as $args) {
+      $t= $variation ? new TestVariation($test, $args) : $test;
+      $timer->start();
+
+      $tearDown= function($test, $error) { return $error; };
+      try {
+
+        // Before and after tests
+        foreach ($actions as $action) {
+          $this->invoke([$action, 'beforeTest'], $test);
+          $tearDown= function($test, $error) use($tearDown, $action) {
+            $propagated= $tearDown($test, $error);
+            try {
+              $this->invoke([$action, 'afterTest'], $test);
+              return $propagated;
+            } catch (Throwable $t) {
+              $propagated && $t->setCause($propagated);
+              return $t;
+            }
+          };
+        }
+
+        // Setup and teardown
+        $this->invoke([$test, 'setUp'], $test);
+        $tearDown= function($test, $error) use($tearDown) {
+          try {
+            $this->invoke([$test, 'tearDown'], null);
+            return $tearDown($test, $error);
+          } catch (Throwable $t) {
+            $error && $t->setCause($error);
+            return $tearDown($test, $t);
+          }
+        };
+
+        // Run test
+        $method->invoke($test, is_array($args) ? $args : [$args]);
+        $thrown= $tearDown($test, null);
+      } catch (TestAborted $aborted) {
+        $tearDown($test, $aborted);
+        $this->record($aborted->type(), $aborted->outcome($t, $timer));
+        continue;
+      } catch (TargetInvocationException $invoke) {
+        $thrown= $tearDown($test, $invoke->getCause());
+      } catch (Throwable $error) {
+        $thrown= $tearDown($test, $error);
+      }
+
+      // Check outcome
+      $time= $timer->elapsedTime();
+      if ($eta && $time > $eta) {
+        $this->record('testFailed', new TestAssertionFailed($t, new TimedOut($eta, $time), $time));
+      } else if ($thrown) {
+        if ($expected && $expected[0]->isInstance($thrown)) {
+          if ($expected[1] && !preg_match($expected[1], $thrown->getMessage())) {
+            $this->record('testFailed', new TestAssertionFailed($t, new ExpectedMessageDiffers($expected[1], $thrown), $time));
+          } else if ($errors= Errors::raised()) {
+            $this->record('testWarning', new TestWarning($t, $errors, $time));
+          } else {
+            $this->record('testSucceeded', new TestExpectationMet($t, $time));
+          }
+        } else if ($expected && !$expected[0]->isInstance($thrown)) {
+          $this->record('testFailed', new TestAssertionFailed($t, new DidNotCatch($expected[0], $thrown), $time));
+        } else if ($thrown instanceof TestAborted) {
+          $this->record($thrown->type(), $thrown->outcome($t, $timer));
+        } else {
+          $this->record('testError', new TestError($t, $thrown, $time));
+        }
+      } else if ($expected) {
+        $this->record('testFailed', new TestAssertionFailed($t, new DidNotCatch($expected[0]), $time));
+      } else if ($errors= Errors::raised()) {
+        $this->record('testWarning', new TestWarning($t, $errors, $time));
+      } else {
+        $this->record('testSucceeded', new TestExpectationMet($t, $time));
+      }
+    }
+  }
+
+  /**
+   * Runs a single test group
+   *
+   * @param  unittest.TestGroup $group
+   * @return void
+   */
+  public function one(TestGroup $group) {
+    $class= $group->type();
+
+    try {
+      $this->beforeClass($class);
+    } catch (PrerequisitesNotMetError $e) {
+      foreach ($group->tests() as $test) {
+        $this->record('testSkipped', new TestPrerequisitesNotMet($test, $e, 0.0));
+      }
+      return;
+    }
+
+    foreach ($group->tests() as $test) {
+      $this->run($test);
+    }
+    $this->afterClass($class);
+  }
+
+  /**
+   * Runs test groups
+   *
+   * @param  [:unittest.TestGroup[]] $sources
+   * @return void
+   */
+  public function all($sources) {
+    foreach ($sources as $classname => $groups) {
+      $class= new XPClass($classname);
+
+      try {
+        $this->beforeClass($class);
+      } catch (PrerequisitesNotMetError $e) {
+        foreach ($groups as $group) {
+          foreach ($group->tests() as $test) {
+            $this->record('testSkipped', new TestPrerequisitesNotMet($test, $e, 0.0));
+          }
+        }
+        continue;
+      }
+
+      foreach ($groups as $group) {
+        foreach ($group->tests() as $test) {
+          $this->run($test);
+        }
+      }
+      $this->afterClass($class);
+    }
+  }
+}

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -322,30 +322,12 @@ class TestRun {
   /**
    * Runs test groups
    *
-   * @param  [:unittest.TestGroup[]] $sources
+   * @param  unittest.TestGroup[] $groups
    * @return void
    */
-  public function all($sources) {
-    foreach ($sources as $classname => $groups) {
-      $class= new XPClass($classname);
-
-      try {
-        $this->beforeClass($class);
-      } catch (PrerequisitesNotMetError $e) {
-        foreach ($groups as $group) {
-          foreach ($group->tests() as $test) {
-            $this->record('testSkipped', new TestPrerequisitesNotMet($test, $e, 0.0));
-          }
-        }
-        continue;
-      }
-
-      foreach ($groups as $group) {
-        foreach ($group->tests() as $test) {
-          $this->run($test);
-        }
-      }
-      $this->afterClass($class);
+  public function all($groups) {
+    foreach ($groups as $group) {
+      $this->one($group);
     }
   }
 }

--- a/src/main/php/unittest/TestSkipped.class.php
+++ b/src/main/php/unittest/TestSkipped.class.php
@@ -1,10 +1,35 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Indicates a test was skipped
  *
- * @see      xp://unittest.TestPrerequisitesNotMet
+ * @see   xp://unittest.TestPrerequisitesNotMet
  */
-interface TestSkipped extends TestOutcome {
+class TestSkipped extends TestOutcome {
+  public $reason;
 
+  /** @return string */
+  public function toString() {
+    return parent::toString()." {\n  ".str_replace("\n", "\n  ", Objects::stringOf($this->reason))."\n}";
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return Objects::hashOf([$this->test, $this->elapsed, $this->reason]);
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->test, $this->elapsed, $this->reason], [$value->test, $this->elapsed, $value->reason])
+      : 1
+    ;
+  }
 }

--- a/src/main/php/unittest/TestSuccess.class.php
+++ b/src/main/php/unittest/TestSuccess.class.php
@@ -5,6 +5,6 @@
  *
  * @see   xp://unittest.TestExpectationMet
  */
-interface TestSuccess extends TestOutcome {
+class TestSuccess extends TestOutcome {
 
 }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -326,8 +326,6 @@ class TestSuite implements \lang\Value {
         $thrown= $tearDown($test, $error);
       }
 
-      $timer->stop();
-
       // Check outcome
       if ($eta && $timer->elapsedTime() > $eta) {
         $report('testFailed', TestAssertionFailed::class, new AssertionFailedError(new FormattedMessage(

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -136,18 +136,17 @@ class TestSuite implements \lang\Value {
    * @return unittest.TestResult
    */
   private function runThis($target) {
-    $result= new TestResult();
+    $run= new TestRun(new TestResult(), $this->listeners);
 
-    $run= new TestRun($result, $this->listeners);
-    $run->notify('testRunStarted', [$this]);
+    $run->start($this);
     try {
       $target($run);
-      $run->notify('testRunFinished', [$this, $result, null]);
+      $run->finish($this);
     } catch (StopTests $stop) {
-      $run->notify('testRunFinished', [$this, $result, $stop]);
+      $run->abort($this, $stop);
     }
 
-    return $result;
+    return $run->result();
   }
 
   /**

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -168,7 +168,11 @@ class TestSuite implements \lang\Value {
    * @return unittest.TestResult
    */
   public function run() {
-    return $this->runThis(function($run) { $run->all($this->sources); });
+    return $this->runThis(function($run) {
+      foreach ($this->sources as $classname => $groups) {
+        $run->all($groups);
+      }
+    });
   }
 
   /** @return string */

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -339,8 +339,8 @@ class TestSuite implements \lang\Value {
         if ($expected && $expected[0]->isInstance($thrown)) {
           if ($expected[1] && !preg_match($expected[1], $thrown->getMessage())) {
             $this->record($result, 'testFailed', new TestAssertionFailed($t, new ExpectedMessageDiffers($expected[1], $thrown), $time));
-          } else if (sizeof(\xp::$errors) > 0) {
-            $this->record($result, 'testWarning', new TestWarning($t, $this->formatErrors(\xp::$errors), $time));
+          } else if (Errors::present()) {
+            $this->record($result, 'testWarning', new TestWarning($t, Errors::all(), $time));
           } else {
             $this->record($result, 'testSucceeded', new TestExpectationMet($t, $time));
           }
@@ -353,38 +353,12 @@ class TestSuite implements \lang\Value {
         }
       } else if ($expected) {
         $this->record($result, 'testFailed', new TestAssertionFailed($t, new DidNotCatch($expected[0]), $time));
-      } else if (sizeof(\xp::$errors) > 0) {
-        $this->record($result, 'testWarning', new TestWarning($t, $this->formatErrors(\xp::$errors), $time));
+      } else if (Errors::present()) {
+        $this->record($result, 'testWarning', new TestWarning($t, Errors::all(), $time));
       } else {
         $this->record($result, 'testSucceeded', new TestExpectationMet($t, $time));
       }
     }
-  }
-
-  /**
-   * Format errors from xp registry
-   *
-   * @param   [:string[]] registry
-   * @return  string[]
-   */
-  protected function formatErrors($registry) {
-    $w= [];
-    foreach ($registry as $file => $lookup) {
-      foreach ($lookup as $line => $messages) {
-        foreach ($messages as $message => $detail) {
-          $w[]= sprintf(
-            '"%s" in %s::%s() (%s, line %d, occured %s)',
-            $message,
-            $detail['class'],
-            $detail['method'],
-            basename($file),
-            $line,
-            1 === $detail['cnt'] ? 'once' : $detail['cnt'].' times'
-          );
-        }
-      }
-    }
-    return $w;
   }
 
   /**

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -225,7 +225,7 @@ class TestSuite implements \lang\Value {
    */
   protected function record($result, $type, $outcome) {
     $this->notifyListeners($type, [$result->record($outcome)]);
-    \xp::gc();
+    Errors::clear();
   }
 
   /**
@@ -283,7 +283,7 @@ class TestSuite implements \lang\Value {
     );
 
     $timer= new Timer();
-    \xp::gc();
+    Errors::clear();
     foreach ($values as $args) {
       $t= $variation ? new TestVariation($test, $args) : $test;
       $timer->start();
@@ -339,8 +339,8 @@ class TestSuite implements \lang\Value {
         if ($expected && $expected[0]->isInstance($thrown)) {
           if ($expected[1] && !preg_match($expected[1], $thrown->getMessage())) {
             $this->record($result, 'testFailed', new TestAssertionFailed($t, new ExpectedMessageDiffers($expected[1], $thrown), $time));
-          } else if (Errors::present()) {
-            $this->record($result, 'testWarning', new TestWarning($t, Errors::all(), $time));
+          } else if ($errors= Errors::raised()) {
+            $this->record($result, 'testWarning', new TestWarning($t, $errors, $time));
           } else {
             $this->record($result, 'testSucceeded', new TestExpectationMet($t, $time));
           }
@@ -353,8 +353,8 @@ class TestSuite implements \lang\Value {
         }
       } else if ($expected) {
         $this->record($result, 'testFailed', new TestAssertionFailed($t, new DidNotCatch($expected[0]), $time));
-      } else if (Errors::present()) {
-        $this->record($result, 'testWarning', new TestWarning($t, Errors::all(), $time));
+      } else if ($errors= Errors::raised()) {
+        $this->record($result, 'testWarning', new TestWarning($t, $errors, $time));
       } else {
         $this->record($result, 'testSucceeded', new TestExpectationMet($t, $time));
       }

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -65,7 +65,7 @@ class TestSuite implements \lang\Value {
     }
     return $numTests;
   }
-  
+
   /**
    * Remove all tests
    *
@@ -74,7 +74,7 @@ class TestSuite implements \lang\Value {
   public function clearTests() {
     $this->sources= [];
   }
-  
+
   /**
    * Returns test at a given position
    *
@@ -273,7 +273,6 @@ class TestSuite implements \lang\Value {
 
     $timer= new Timer();
     $report= function($type, $outcome, $arg) use($result, $timer, &$t) {
-      $timer->stop();
       $this->notifyListeners($type, [$result->set($t, new $outcome($t, $arg, $timer->elapsedTime()))]);
       \xp::gc();
     };
@@ -365,7 +364,7 @@ class TestSuite implements \lang\Value {
       }
     }
   }
-  
+
   /**
    * Format errors from xp registry
    *
@@ -391,7 +390,7 @@ class TestSuite implements \lang\Value {
     }
     return $w;
   }
-  
+
   /**
    * Notify listeners
    *
@@ -481,7 +480,7 @@ class TestSuite implements \lang\Value {
 
     return $result;
   }
-  
+
   /**
    * Run this test suite
    *

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -32,15 +32,16 @@ class TestSuite implements \lang\Value {
   /**
    * Add a test class
    *
-   * @param  lang.XPClass $class
+   * @param  string|lang.XPClass $class
    * @param  var[] $arguments default [] arguments to pass to test case constructor
    * @return lang.XPClass
    * @throws lang.IllegalArgumentException in case given argument is not a testcase class
    * @throws util.NoSuchElementException in case given testcase class does not contain any tests
    */
-  public function addTestClass(XPClass $class, $arguments= []) {
-    $this->sources[$class->literal()][]= new TestClass($class, $arguments);
-    return $class;
+  public function addTestClass($class, $arguments= []) {
+    $type= $class instanceof XPClass ? $class : XPClass::forName($class);
+    $this->sources[$type->literal()][]= new TestClass($type, $arguments);
+    return $type;
   }
 
   /**

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -218,10 +218,9 @@ class TestSuite implements \lang\Value {
   /**
    * Run a test case.
    *
-   * @param   unittest.TestCase test
-   * @param   unittest.TestResult result
-   * @return  void
-   * @throws  lang.MethodNotImplementedException
+   * @param  unittest.TestCase $test
+   * @param  unittest.TestResult $result
+   * @return void
    */
   protected function runInternal($test, $result) {
     $class= typeof($test);

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -12,7 +12,7 @@ use util\Objects;
  * @see    http://junit.sourceforge.net/doc/testinfected/testing.htm
  */
 class TestSuite implements \lang\Value {
-  protected $listeners= [];
+  private $listeners= [];
   private $sources= [];
 
   /**

--- a/src/main/php/unittest/TestWarning.class.php
+++ b/src/main/php/unittest/TestWarning.class.php
@@ -1,63 +1,25 @@
 <?php namespace unittest;
 
-use util\Objects;
-
 /**
  * Indicates a test failed
  *
  * @see      xp://unittest.TestFailure
  */
-class TestWarning implements TestFailure {
-  public
-    $reason   = null,
-    $test     = null,
-    $elapsed  = 0.0;
+class TestWarning extends TestFailure {
     
   /**
    * Constructor
    *
-   * @param   unittest.TestCase test
-   * @param   string[] warnings
-   * @param   float elapsed
+   * @param  unittest.TestCase $test
+   * @param  string[] $warnings
+   * @param  double $elapsed
    */
   public function __construct(TestCase $test, array $warnings, $elapsed) {
-    $this->test= $test;
+    parent::__construct($test, $elapsed);
     $this->reason= new Warnings($warnings);
-    $this->elapsed= $elapsed;
-  }
-
-  /**
-   * Returns elapsed time
-   *
-   * @return  float
-   */
-  public function elapsed() {
-    return $this->elapsed;
   }
 
   /** @return string */
-  public function toString() {
-    return sprintf(
-      "%s(test= %s, time= %.3f seconds) {\n  %s\n}",
-      nameof($this),
-      $this->test->getName(true),
-      $this->elapsed,
-      str_replace("\n", "\n  ", $this->reason->compoundMessage())
-    );
-  }
+  protected function formatReason() { return $this->reason->compoundMessage(); }
 
-  /** @return string */
-  public function hashCode() {
-    return Objects::hashOf([null => $this->test] + $this->reason->all());
-  }
-
-  /**
-   * Compares this test outcome to a given value
-   *
-   * @param  var $value
-   * @return int
-   */
-  public function compareTo($value) {
-    return $value instanceof self ? Objects::compare([$this->test, $this->reason], [$value->test, $value->reason]) : 1;
-  }
 }

--- a/src/main/php/unittest/TimedOut.class.php
+++ b/src/main/php/unittest/TimedOut.class.php
@@ -1,0 +1,30 @@
+<?php namespace unittest;
+
+class TimedOut implements AssertionFailedMessage {
+  private $expected, $taken;
+
+  /**
+   * Constructor
+   *
+   * @param   double $expected
+   * @param   double $taken
+   */
+  public function __construct($expected, $taken) {
+    $this->expected= $expected;
+    $this->taken= $taken;
+  }
+
+
+  /**
+   * Return formatted message
+   *
+   * @return  string
+   */
+  public function format() {
+    return sprintf(
+      'Test runtime of %.3f seconds longer than eta of %.3f seconds',
+      $this->taken,
+      $this->expected
+    );
+  }
+}

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -119,11 +119,12 @@ class SuiteTest extends TestCase {
 
   #[@test]
   public function adding_a_testclass_returns_added_class() {
-    $class= ClassLoader::defineClass($this->name, 'unittest.TestCase', [], '{
-      #[@test]
-      public function fixture() { }
-    }');
-    $this->assertEquals($class, $this->suite->addTestClass($class));
+    $this->assertEquals(typeof($this), $this->suite->addTestClass(typeof($this)));
+  }
+
+  #[@test]
+  public function adding_a_testclass_by_name_returns_added_class() {
+    $this->assertEquals(typeof($this), $this->suite->addTestClass(self::class));
   }
 
   #[@test]

--- a/src/test/php/unittest/tests/TestActionTest.class.php
+++ b/src/test/php/unittest/tests/TestActionTest.class.php
@@ -104,7 +104,6 @@ class TestActionTest extends TestCase {
 
   #[@test]
   public function test_action_with_arguments() {
-
     ClassLoader::defineClass('unittest.tests.PlatformVerification', $this->parent, ['unittest.TestAction'], '{
       protected $platform;
 
@@ -130,6 +129,21 @@ class TestActionTest extends TestCase {
     $outcome= $this->suite->runTest($test)->outcomeOf($test);
     $this->assertInstanceOf(TestPrerequisitesNotMet::class, $outcome);
     $this->assertEquals(['Test'], $outcome->reason->prerequisites);
+  }
+
+  #[@test]
+  public function skip_test_via_skip() {
+    ClassLoader::defineClass('unittest.tests.SkipTest', $this->parent, ['unittest.TestAction'], [
+      'beforeTest' => function(TestCase $t) { $t->skip('Not run'); },
+      'afterTest' => function(TestCase $t) { }
+    ]);
+    $test= newinstance(TestCase::class, ['fixture'], [
+      '#[@test, @action([new \unittest\tests\SkipTest()])] fixture' => function() {
+        throw new IllegalStateException('This test should have been skipped');
+      }
+    ]);
+    $r= $this->suite->runTest($test);
+    $this->assertEquals(1, $r->skipCount());
   }
 
   #[@test]

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -49,7 +49,8 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestExpectationMet($test, $variant) {
     $this->assertStringRepresentation(
       'unittest.TestExpectationMet(test= %s, time= 0.000 seconds)',
-      new TestExpectationMet($test, 0.0), $variant
+      new TestExpectationMet($test, 0.0),
+      $variant
     );
   }
 
@@ -57,8 +58,9 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestAssertionFailed($test, $variant) {
     $assert= new AssertionFailedError('Not equal', 1, 2);
     $this->assertStringRepresentation(
-      "unittest.TestAssertionFailed(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($assert, '  ')."\n }",
-      new TestAssertionFailed($test, $assert, 0.0), $variant
+      "unittest.TestAssertionFailed(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($assert, '  ')."\n}",
+      new TestAssertionFailed($test, $assert, 0.0),
+      $variant
     );
   }
 
@@ -66,8 +68,9 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestError($test, $variant) {
     $error= new Error('Out of memory');
     $this->assertStringRepresentation(
-      "unittest.TestError(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($error, '  ')."\n }",
-      new TestError($test, $error, 0.0), $variant
+      "unittest.TestError(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($error, '  ')."\n}",
+      new TestError($test, $error, 0.0),
+      $variant
     );
   }
 
@@ -75,16 +78,18 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestPrerequisitesNotMet($test, $variant) {
     $prerequisites= new PrerequisitesNotMetError('Initialization failed');
     $this->assertStringRepresentation(
-      "unittest.TestPrerequisitesNotMet(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($prerequisites, '  ')."\n }",
-      new TestPrerequisitesNotMet($test, $prerequisites, 0.0), $variant
+      "unittest.TestPrerequisitesNotMet(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($prerequisites, '  ')."\n}",
+      new TestPrerequisitesNotMet($test, $prerequisites, 0.0),
+      $variant
     );
   }
 
   #[@test, @values('fixtures')]
   public function string_representation_of_TestNotRun($test, $variant) {
     $this->assertStringRepresentation(
-      "unittest.TestNotRun(test= %s, time= 0.000 seconds) {\n  \"Ignored\"\n }",
-      new TestNotRun($test, 'Ignored', 0.0), $variant
+      "unittest.TestNotRun(test= %s, time= 0.000 seconds) {\n  \"Ignored\"\n}",
+      new TestNotRun($test, 'Ignored', 0.0),
+      $variant
     );
   }
 


### PR DESCRIPTION
This pull request fixes #23, including a refactoring which introduces a new base exception class, `unittest.TestAborted`. AssertionFailedError, PrerequisitesNotMetError and IgnoredBecause all extend this class and make handling them inside TestSuite::runInternal() far easier, removing duplicated code.