### PR TITLE
Map values

### DIFF
--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -49,6 +49,12 @@ class TestRun {
     if (!is_array($annotation)) {               // values("source")
       $source= $annotation;
       $args= [];
+    } else if (isset($annotation['map'])) {     // values(map= ["test" => true, ...])
+      $values= [];
+      foreach ($annotation['map'] as $key => $value) {
+        $values[]= [$key, $value];
+      }
+      return $values;
     } else if (isset($annotation['source'])) {  // values(source= "src" [, args= ...])
       $source= $annotation['source'];
       $args= isset($annotation['args']) ? $annotation['args'] : [];

--- a/src/test/php/unittest/tests/AssertionMessagesTest.class.php
+++ b/src/test/php/unittest/tests/AssertionMessagesTest.class.php
@@ -42,8 +42,8 @@ class AssertionMessagesTest extends TestCase {
   #[@test]
   public function differentPrimitives() {
     $this->assertFormatted(
-      'expected [int:2] but was [double:2] using: \'equals\'',
-      new ComparisonFailedMessage('equals', 2, 2.0)
+      'expected [int:2] but was [bool:false] using: \'equals\'',
+      new ComparisonFailedMessage('equals', 2, false)
     );
   }
 

--- a/src/test/php/unittest/tests/ValuesTest.class.php
+++ b/src/test/php/unittest/tests/ValuesTest.class.php
@@ -46,6 +46,20 @@ class ValuesTest extends TestCase {
   }
 
   #[@test]
+  public function inline_value_map() {
+    $test= newinstance(TestCase::class, ['fixture'], '{
+      public $values= [];
+
+      #[@test, @values(map= ["a" => "b", "c" => "d"])]
+      public function fixture($key, $value) {
+        $this->values[]= [$key, $value];
+      }
+    }');
+    $this->suite->runTest($test);
+    $this->assertEquals([['a', 'b'], ['c', 'd']], $test->values);
+  }
+
+  #[@test]
   public function local_value_source() {
     $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];


### PR DESCRIPTION
This pull request adds a way to support a map containing the arguments to be passed to a value function.

## Example

```php
class LiteralsTest extends ParseTest {

  #[@test, @values(map= [
  #  '0' => 0,
  #  '1' => 1
  #])]
  public function integer($input, $expect) {
    $this->assertNodes([['(literal)' => $expect]], $this->parse($input.';'));
  }
}
```

See also the original unittest parameterization RFC, xp-framework/rfc#267