### PR TITLE
Replace all occurrences of xp::stringOf() with Objects::stringOf()

### DIFF
--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -2,6 +2,7 @@
 
 use lang\IllegalArgumentException;
 use util\NoSuchElementException;
+use util\Objects;
 
 class TestClass extends TestGroup {
   private $class, $arguments;
@@ -20,7 +21,7 @@ class TestClass extends TestGroup {
    */
   public function __construct($class, $arguments) {
     if (!$class->isSubclassOf(self::$base)) {
-      throw new IllegalArgumentException('Given argument is not a TestCase class ('.\xp::stringOf($class).')');
+      throw new IllegalArgumentException('Given argument is not a TestCase class ('.Objects::stringOf($class).')');
     }
 
     foreach ($class->getMethods() as $method) {

--- a/src/main/php/unittest/TestResult.class.php
+++ b/src/main/php/unittest/TestResult.class.php
@@ -135,9 +135,9 @@ class TestResult implements \lang\Value {
    * @return  int
    */
   public function count() {
-    return sizeof($this->succeeded)+ sizeof($this->failed)+ sizeof($this->skipped);
+    return sizeof($this->succeeded) + sizeof($this->failed) + sizeof($this->skipped);
   }
-  
+
   /**
    * Returns elapsed time
    *

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -1,5 +1,7 @@
 <?php namespace unittest;
 
+use util\Objects;
+
 /**
  * Test case variation
  *
@@ -17,7 +19,7 @@ class TestVariation extends TestCase {
   public function __construct($base, $args) {
     $uniq= '';
     foreach ((array)$args as $arg) {
-      $uniq.= ', '.\xp::stringOf($arg);
+      $uniq.= ', '.Objects::stringOf($arg);
     }
     parent::__construct($base->getName().'('.substr($uniq, 2).')');
     $this->base= $base;

--- a/src/main/php/xp/unittest/XmlTestListener.class.php
+++ b/src/main/php/xp/unittest/XmlTestListener.class.php
@@ -4,6 +4,7 @@ use io\streams\OutputStreamWriter;
 use xml\Tree;
 use util\collections\HashTable;
 use lang\XPClass;
+use util\Objects;
 
 /**
  * Creates an XML file suitable for importing into continuous integration
@@ -64,7 +65,7 @@ class XmlTestListener implements TestListener {
       "%s(%s)\n%s \n\n%s:%d\n\n",
       $testClass->getName(),
       $error->test->getName(),
-      \xp::stringOf($error->reason),
+      Objects::stringOf($error->reason),
       $this->uriFor($testClass),
       $this->lineFor($testClass, $error->test->getName())
     );

--- a/src/test/php/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/unittest/tests/AssertionsTest.class.php
@@ -2,6 +2,7 @@
  
 use unittest\TestCase;
 use unittest\AssertionFailedError;
+use util\Objects;
 
 /**
  * Test assertion methods
@@ -102,7 +103,7 @@ class AssertionsTest extends TestCase {
   #[@test]
   public function hashesOrderNotRelevant() {
     $hash= ['&' => '&amp;', '"' => '&quot;'];
-    $this->assertEquals($hash, array_reverse($hash, true), \xp::stringOf($hash));
+    $this->assertEquals($hash, array_reverse($hash, true), Objects::stringOf($hash));
   }    
 
   #[@test, @values([1, 0, -1])]

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -59,7 +59,7 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestAssertionFailed($test, $variant) {
     $assert= new AssertionFailedError('Not equal', 1, 2);
     $this->assertStringRepresentation(
-      "unittest.TestAssertionFailed(test= %s, time= 0.000 seconds) {\n  ".Objects::stringOf($assert, '  ')."\n}",
+      "unittest.TestAssertionFailed(test= %s, time= 0.000 seconds) {\n  ".str_replace("\n", "\n  ", Objects::stringOf($assert))."\n}",
       new TestAssertionFailed($test, $assert, 0.0),
       $variant
     );
@@ -69,7 +69,7 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestError($test, $variant) {
     $error= new Error('Out of memory');
     $this->assertStringRepresentation(
-      "unittest.TestError(test= %s, time= 0.000 seconds) {\n  ".Objects::stringOf($error, '  ')."\n}",
+      "unittest.TestError(test= %s, time= 0.000 seconds) {\n  ".str_replace("\n", "\n  ", Objects::stringOf($error))."\n}",
       new TestError($test, $error, 0.0),
       $variant
     );
@@ -79,7 +79,7 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestPrerequisitesNotMet($test, $variant) {
     $prerequisites= new PrerequisitesNotMetError('Initialization failed');
     $this->assertStringRepresentation(
-      "unittest.TestPrerequisitesNotMet(test= %s, time= 0.000 seconds) {\n  ".Objects::stringOf($prerequisites, '  ')."\n}",
+      "unittest.TestPrerequisitesNotMet(test= %s, time= 0.000 seconds) {\n  ".str_replace("\n", "\n  ", Objects::stringOf($prerequisites))."\n}",
       new TestPrerequisitesNotMet($test, $prerequisites, 0.0),
       $variant
     );

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -11,6 +11,7 @@ use unittest\TestVariation;
 use unittest\PrerequisitesNotMetError;
 use unittest\AssertionFailedError;
 use lang\Error;
+use util\Objects;
 
 /**
  * Test TestOutcome implementations
@@ -58,7 +59,7 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestAssertionFailed($test, $variant) {
     $assert= new AssertionFailedError('Not equal', 1, 2);
     $this->assertStringRepresentation(
-      "unittest.TestAssertionFailed(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($assert, '  ')."\n}",
+      "unittest.TestAssertionFailed(test= %s, time= 0.000 seconds) {\n  ".Objects::stringOf($assert, '  ')."\n}",
       new TestAssertionFailed($test, $assert, 0.0),
       $variant
     );
@@ -68,7 +69,7 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestError($test, $variant) {
     $error= new Error('Out of memory');
     $this->assertStringRepresentation(
-      "unittest.TestError(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($error, '  ')."\n}",
+      "unittest.TestError(test= %s, time= 0.000 seconds) {\n  ".Objects::stringOf($error, '  ')."\n}",
       new TestError($test, $error, 0.0),
       $variant
     );
@@ -78,7 +79,7 @@ class TestOutcomeTest extends \unittest\TestCase {
   public function string_representation_of_TestPrerequisitesNotMet($test, $variant) {
     $prerequisites= new PrerequisitesNotMetError('Initialization failed');
     $this->assertStringRepresentation(
-      "unittest.TestPrerequisitesNotMet(test= %s, time= 0.000 seconds) {\n  ".\xp::stringOf($prerequisites, '  ')."\n}",
+      "unittest.TestPrerequisitesNotMet(test= %s, time= 0.000 seconds) {\n  ".Objects::stringOf($prerequisites, '  ')."\n}",
       new TestPrerequisitesNotMet($test, $prerequisites, 0.0),
       $variant
     );

--- a/src/test/php/unittest/tests/VerifyThatTest.class.php
+++ b/src/test/php/unittest/tests/VerifyThatTest.class.php
@@ -4,6 +4,7 @@ use unittest\TestExpectationMet;
 use unittest\TestPrerequisitesNotMet;
 use unittest\TestCase;
 use unittest\TestSuite;
+use util\Objects;
 
 /**
  * Test VerifyThat class
@@ -26,7 +27,7 @@ class VerifyThatTest extends TestCase {
    */
   protected function assertSucceeds($test) {
     $outcome= $this->suite->runTest($test)->outcomeOf($test);
-    $this->assertInstanceOf(TestExpectationMet::class, $outcome, \xp::stringOf($outcome));
+    $this->assertInstanceOf(TestExpectationMet::class, $outcome, Objects::stringOf($outcome));
   }
 
   /**
@@ -38,7 +39,7 @@ class VerifyThatTest extends TestCase {
    */
   protected function assertSkipped($prerequisites, $test) {
     $outcome= $this->suite->runTest($test)->outcomeOf($test);
-    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $outcome, \xp::stringOf($outcome));
+    $this->assertInstanceOf(TestPrerequisitesNotMet::class, $outcome, Objects::stringOf($outcome));
     $this->assertEquals($prerequisites, $outcome->reason->prerequisites);
   }
 


### PR DESCRIPTION
`xp::string()` has been deprecated since XP9