### PR TITLE
Allow passing subfolders directly as source...

### DIFF
--- a/src/test/php/unittest/tests/AbstractSourceTest.class.php
+++ b/src/test/php/unittest/tests/AbstractSourceTest.class.php
@@ -1,0 +1,22 @@
+<?php namespace unittest\tests;
+
+use unittest\TestCase;
+
+abstract class AbstractSourceTest extends TestCase {
+
+  /**
+   * Assertion helper
+   *
+   * @param  string[] $expected Class names
+   * @param  xp.unittest.sources.AbstractSource $source
+   * @throws unittest.AssertionFailedError
+   */
+  protected function assertFinds($expected, $source) {
+    $found= [];
+    foreach ($source->classes() as $class) {
+      $found[]= $class->getName();
+    }
+    sort($found);
+    $this->assertEquals($expected, $found);
+  }
+}

--- a/src/test/php/unittest/tests/FolderSourceTest.class.php
+++ b/src/test/php/unittest/tests/FolderSourceTest.class.php
@@ -20,8 +20,8 @@ class FolderSourceTest extends AbstractSourceTest {
   public function finds_classes() {
     $expected= [
       'unittest.tests.sources.InBase',
-      'unittest.tests.sources.util.Base',
-      'unittest.tests.sources.util.InUtil'
+      'unittest.tests.sources.util.InUtil',
+      'unittest.tests.sources.util.UtilityTest',
     ];
     $this->assertFinds($expected, new FolderSource(new Folder('src/test/php/unittest/tests/sources')));
   }
@@ -29,8 +29,8 @@ class FolderSourceTest extends AbstractSourceTest {
   #[@test]
   public function finds_classes_in_subpackage() {
     $expected= [
-      'unittest.tests.sources.util.Base',
-      'unittest.tests.sources.util.InUtil'
+      'unittest.tests.sources.util.InUtil',
+      'unittest.tests.sources.util.UtilityTest',
     ];
     $this->assertFinds($expected, new FolderSource(new Folder('src/test/php/unittest/tests/sources/util')));
   }

--- a/src/test/php/unittest/tests/FolderSourceTest.class.php
+++ b/src/test/php/unittest/tests/FolderSourceTest.class.php
@@ -1,0 +1,37 @@
+<?php namespace unittest\tests;
+
+use io\Folder;
+use lang\IllegalArgumentException;
+use xp\unittest\sources\FolderSource;
+
+class FolderSourceTest extends AbstractSourceTest {
+
+  #[@test]
+  public function can_create() {
+    new FolderSource(new Folder('src/test/php'));
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function raises_error_when_created_with_non_class_path() {
+    new FolderSource(new Folder('/'));
+  }
+
+  #[@test]
+  public function finds_classes() {
+    $expected= [
+      'unittest.tests.sources.InBase',
+      'unittest.tests.sources.util.Base',
+      'unittest.tests.sources.util.InUtil'
+    ];
+    $this->assertFinds($expected, new FolderSource(new Folder('src/test/php/unittest/tests/sources')));
+  }
+
+  #[@test]
+  public function finds_classes_in_subpackage() {
+    $expected= [
+      'unittest.tests.sources.util.Base',
+      'unittest.tests.sources.util.InUtil'
+    ];
+    $this->assertFinds($expected, new FolderSource(new Folder('src/test/php/unittest/tests/sources/util')));
+  }
+}

--- a/src/test/php/unittest/tests/sources/InBase.class.php
+++ b/src/test/php/unittest/tests/sources/InBase.class.php
@@ -1,0 +1,11 @@
+<?php namespace unittest\tests\sources;
+
+use unittest\TestCase;
+
+class InBase extends TestCase {
+
+  #[@test]
+  public function test() {
+    $this->assertTrue(true);
+  }
+}

--- a/src/test/php/unittest/tests/sources/util/Base.class.php
+++ b/src/test/php/unittest/tests/sources/util/Base.class.php
@@ -1,0 +1,11 @@
+<?php namespace unittest\tests\sources\util;
+
+use unittest\TestCase;
+
+abstract class Base extends TestCase {
+
+  #[@test]
+  public function test() {
+    $this->assertTrue(true);
+  }
+}

--- a/src/test/php/unittest/tests/sources/util/InUtil.class.php
+++ b/src/test/php/unittest/tests/sources/util/InUtil.class.php
@@ -1,0 +1,5 @@
+<?php namespace unittest\tests\sources\util;
+
+class InUtil extends Base {
+
+}

--- a/src/test/php/unittest/tests/sources/util/InUtil.class.php
+++ b/src/test/php/unittest/tests/sources/util/InUtil.class.php
@@ -1,5 +1,5 @@
 <?php namespace unittest\tests\sources\util;
 
-class InUtil extends Base {
+class InUtil extends UtilityTest {
 
 }

--- a/src/test/php/unittest/tests/sources/util/UtilityTest.class.php
+++ b/src/test/php/unittest/tests/sources/util/UtilityTest.class.php
@@ -2,7 +2,7 @@
 
 use unittest\TestCase;
 
-abstract class Base extends TestCase {
+abstract class UtilityTest extends TestCase {
 
   #[@test]
   public function test() {


### PR DESCRIPTION
...only running the tests therein as a consequence. Previously, the class loader was simply queried for *all* classes inside any loader the given path was a part of.

## Example

For https://github.com/xp-framework/compiler:

```bash
$ xp test src/test/php/
# ...

♥: 512/512 run (0 skipped), 512 succeeded, 0 failed
Memory used: 6234.56 kB (6285.34 kB peak)
Time taken: 0.223 seconds

$ xp test src/test/php/lang/ast/unittest/emit/
# ...

♥: 252/252 run (0 skipped), 252 succeeded, 0 failed
Memory used: 5352.44 kB (5403.19 kB peak)
Time taken: 0.193 seconds
```

*Without this change, the second command would have run exactly the same tests as the first one!*