### PR TITLE
Add possibility to fail all tests from within `@beforeClass` methods

### DIFF
--- a/src/main/php/unittest/PrerequisitesFailedError.class.php
+++ b/src/main/php/unittest/PrerequisitesFailedError.class.php
@@ -1,0 +1,12 @@
+<?php namespace unittest;
+
+/**
+ * Indicates prerequisites have failed
+ *
+ * @see  xp://unittest.TestPrerequisitesNotMet
+ */
+class PrerequisitesFailedError extends PrerequisitesNotMetError {
+
+  /** @return string */
+  public function type() { return 'testFailed'; }
+}

--- a/src/main/php/unittest/PrerequisitesFailedError.class.php
+++ b/src/main/php/unittest/PrerequisitesFailedError.class.php
@@ -5,7 +5,7 @@ use util\profiling\Timer;
 /**
  * Indicates prerequisites have failed
  *
- * @see  xp://unittest.TestPrerequisitesNotMet
+ * @see  xp://unittest.TestPrerequisitesFailed
  */
 class PrerequisitesFailedError extends PrerequisitesNotMetError {
 

--- a/src/main/php/unittest/PrerequisitesFailedError.class.php
+++ b/src/main/php/unittest/PrerequisitesFailedError.class.php
@@ -1,5 +1,7 @@
 <?php namespace unittest;
 
+use util\profiling\Timer;
+
 /**
  * Indicates prerequisites have failed
  *
@@ -9,4 +11,9 @@ class PrerequisitesFailedError extends PrerequisitesNotMetError {
 
   /** @return string */
   public function type() { return 'testFailed'; }
+
+  /** @return unittest.TestOutcome */
+  public function outcome(TestCase $test, Timer $timer) {
+    return new TestPrerequisitesFailed($test, $this, $timer->elapsedTime());
+  }
 }

--- a/src/main/php/unittest/TestPrerequisitesFailed.class.php
+++ b/src/main/php/unittest/TestPrerequisitesFailed.class.php
@@ -1,0 +1,24 @@
+<?php namespace unittest;
+
+/**
+ * Indicates a test failed
+ *
+ * @see      xp://unittest.TestFailure
+ */
+class TestPrerequisitesFailed extends TestFailure {
+    
+  /**
+   * Constructor
+   *
+   * @param  unittest.TestCase $test
+   * @param  unittest.PrerequisitesNotMetError $reason
+   * @param  double $elapsed
+   */
+  public function __construct(TestCase $test, PrerequisitesFailedError $reason, $elapsed) {
+    parent::__construct($test, $elapsed);
+    $this->reason= $reason;
+  }
+
+  /** @return string */
+  protected function formatReason() { return $this->reason->toString(); }
+}

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -302,14 +302,10 @@ class TestRun {
   public function one(TestGroup $group) {
     try {
       $group->before();
-    } catch (PrerequisitesFailedError $e) {
-      foreach ($group->tests() as $test) {
-        $this->record('testFailed', new TestPrerequisitesFailed($test, $e, 0.0));
-      }
-      return;
     } catch (PrerequisitesNotMetError $e) {
+      $timer= new Timer();
       foreach ($group->tests() as $test) {
-        $this->record('testSkipped', new TestPrerequisitesNotMet($test, $e, 0.0));
+        $this->record($e->type(), $e->outcome($test, $timer));
       }
       return;
     }

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -1,8 +1,8 @@
 <?php namespace unittest;
 
-use lang\reflect\TargetInvocationException;
 use lang\Throwable;
 use lang\XPClass;
+use lang\reflect\TargetInvocationException;
 use util\profiling\Timer;
 
 class TestRun {
@@ -302,6 +302,11 @@ class TestRun {
   public function one(TestGroup $group) {
     try {
       $group->before();
+    } catch (PrerequisitesFailedError $e) {
+      foreach ($group->tests() as $test) {
+        $this->record('testFailed', new TestPrerequisitesFailed($test, $e, 0.0));
+      }
+      return;
     } catch (PrerequisitesNotMetError $e) {
       foreach ($group->tests() as $test) {
         $this->record('testSkipped', new TestPrerequisitesNotMet($test, $e, 0.0));


### PR DESCRIPTION
Exceptions from `@beforeClass` methods skip all tests if they fail. In certain situations, if may be better to fail them.

This can be done by throwing a `PrerequisitesFailedError` (*instead of a `PrerequisitesNotMetError`*) from these methods.

### Example

```php
use unittest\{TestCase, PrerequisitesFailedError};

class ExampleTest extends TestCase {

  #[@beforeClass]
  public static function startServer() {
    $server= ...;
    try {
      $server->start();
    } catch (CouldNotStartServer $e) {
      throw new PrerequisitesFailedError('Could not start server', $e, [$server]);
    }
  }

  // ...
}
```