### PR TITLE
Add metrics to TestResult

### DIFF
--- a/src/main/php/unittest/TestResult.class.php
+++ b/src/main/php/unittest/TestResult.class.php
@@ -1,7 +1,9 @@
 <?php namespace unittest;
 
-use lang\Runtime;
 use lang\Value;
+use unittest\metrics\MemoryUsed;
+use unittest\metrics\Metric;
+use unittest\metrics\TimeTaken;
 use util\Objects;
 
 /**
@@ -19,13 +21,8 @@ class TestResult implements Value {
 
   /** Initializes metrics */
   public function __construct() {
-    $this->metrics['Memory used']= function() {
-      $rt= Runtime::getInstance();
-      return sprintf('%.2f kB (%.2f kB peak)', $rt->memoryUsage() / 1024, $rt->peakMemoryUsage() / 1024);
-    };
-    $this->metrics['Time taken']= function() {
-      return sprintf('%.3f seconds', $this->elapsed());
-    };
+    $this->metrics['Memory used']= new MemoryUsed();
+    $this->metrics['Time taken']= new TimeTaken($this);
   }
 
   /**
@@ -176,14 +173,11 @@ class TestResult implements Value {
    * Register a metric
    *
    * @param  string $name
-   * @param  function(): string|var $metric
+   * @param  unttest.metrics.Metric
    * @return self
    */
-  public function metric($name, $metric) {
-    $this->metrics[$name]= $metric instanceof \Closure
-      ? $metric
-      : function() use($metric) { return $metric; }
-    ;
+  public function metric($name, Metric $metric) {
+    $this->metrics[$name]= $metric;
     return $this;
   }
 

--- a/src/main/php/unittest/metrics/MemoryUsed.class.php
+++ b/src/main/php/unittest/metrics/MemoryUsed.class.php
@@ -3,11 +3,16 @@
 use lang\Runtime;
 
 class MemoryUsed extends Metric {
-  private $used, $peak;
+  private $runtime, $used, $peak;
+
+  /** @param lang.Runtime $runtime */
+  public function __construct($runtime= null) {
+    $this->runtime= $runtime;
+  }
 
   /** @return void */
   protected function calculate() {
-    $rt= Runtime::getInstance();
+    $rt= $this->runtime ?: Runtime::getInstance();
     $this->used= $rt->memoryUsage();
     $this->peak= $rt->peakMemoryUsage();
   }

--- a/src/main/php/unittest/metrics/MemoryUsed.class.php
+++ b/src/main/php/unittest/metrics/MemoryUsed.class.php
@@ -1,0 +1,24 @@
+<?php namespace unittest\metrics;
+
+use lang\Runtime;
+
+class MemoryUsed extends Metric {
+  private $used, $peak;
+
+  /** @return void */
+  protected function calculate() {
+    $rt= Runtime::getInstance();
+    $this->used= $rt->memoryUsage();
+    $this->peak= $rt->peakMemoryUsage();
+  }
+
+  /** @return string */
+  protected function format() {
+    return sprintf('%.2f kB (%.2f kB peak)', $this->used / 1024, $this->peak / 1024);
+  }
+
+  /** @return var */
+  protected function value() {
+    return $this->used;
+  }
+}

--- a/src/main/php/unittest/metrics/Metric.class.php
+++ b/src/main/php/unittest/metrics/Metric.class.php
@@ -1,0 +1,84 @@
+<?php namespace unittest\metrics;
+
+use lang\Value;
+use util\Objects;
+
+/**
+ * Base class for metrics. Subclasses overwrite the `calculate()`, `format()`
+ * and `value()` methods.
+ *
+ * @test  xp://unittest.tests.MetricsTest
+ */
+abstract class Metric implements Value {
+  private $calculated= false;
+
+  /**
+   * Calculates this metric's values
+   *
+   * @return void
+   */
+  protected abstract function calculate();
+
+  /**
+   * Formats this metric as a string. The `calculate()` method is
+   * guaranteed to have been called!
+   *
+   * @return string
+   */
+  protected abstract function format();
+
+  /**
+   * Returns this metric's value, which is used for comparison. The
+   * `calculate()` method is guaranteed to have been called!
+   *
+   * @return var
+   */
+  protected abstract function value();
+
+  /**
+   * Retrieve a formatted version of this metric
+   *
+   * @param  bool $refresh Defaults to using cached values if available
+   * @return string
+   */
+  public function formatted($refresh= false) {
+    if ($refresh || !$this->calculated) {
+      $this->calculate();
+      $this->calculated= true;
+    }
+    return $this->format();
+  }
+
+  /**
+   * Retrieve the calculated value of this metric
+   *
+   * @param  bool $refresh Defaults to using cached values if available
+   * @return var
+   */
+  public function calculated($refresh= false) {
+    if ($refresh || !$this->calculated) {
+      $this->calculate();
+      $this->calculated= true;
+    }
+    return $this->value();
+  }
+
+  /** @return string */
+  public function toString() { return nameof($this).'<'.$this->formatted().'>'; }
+
+  /** @return string */
+  public function hashCode() { return 'M'.md5($this->formatted()); }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare($this->calculated(), $value->calculated())
+      : 1
+    ;
+  }
+}

--- a/src/main/php/unittest/metrics/TimeTaken.class.php
+++ b/src/main/php/unittest/metrics/TimeTaken.class.php
@@ -1,0 +1,25 @@
+<?php namespace unittest\metrics;
+
+class TimeTaken extends Metric {
+  private $result, $elapsed;
+
+  /** @param unittest.TestResult $result */
+  public function __construct($result) {
+    $this->result= $result;
+  }
+
+  /** @return void */
+  protected function calculate() {
+    $this->elapsed= $this->result->elapsed();
+  }
+
+  /** @return string */
+  protected function format() {
+    return sprintf('%.3f seconds', $this->elapsed);
+  }
+
+  /** @return var */
+  protected function value() {
+    return $this->elapsed;
+  }
+}

--- a/src/main/php/xp/unittest/ColoredBarListener.class.php
+++ b/src/main/php/xp/unittest/ColoredBarListener.class.php
@@ -1,6 +1,7 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
+use unittest\TestListener;
 
 /**
  * Colorful verbose test listener
@@ -14,8 +15,9 @@ use io\streams\OutputStreamWriter;
  *   information out instantly)
  *
  */
-class ColoredBarListener implements \unittest\TestListener {
+class ColoredBarListener implements TestListener {
   const PROGRESS_WIDTH= 10;
+
   private $out= null;
   private $cur, $sum, $len, $status;
   private $stats;
@@ -225,14 +227,8 @@ class ColoredBarListener implements \unittest\TestListener {
       $result->successCount(),
       $result->failureCount()
     );
-    $this->out->writeLinef(
-      'Memory used: %.2f kB (%.2f kB peak)',
-      \lang\Runtime::getInstance()->memoryUsage() / 1024,
-      \lang\Runtime::getInstance()->peakMemoryUsage() / 1024
-    );
-    $this->out->writeLinef(
-      'Time taken: %.3f seconds',
-      $result->elapsed()
-    );
+    foreach ($result->metrics() as $name => $metric) {
+      $this->out->writeLine($name, ': ', $metric->formatted());
+    }
   }
 }

--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -1,17 +1,16 @@
 <?php namespace xp\unittest;
 
-use unittest\TestListener;
-use unittest\ColorizingListener;
-use io\streams\OutputStreamWriter;
 use io\streams\ConsoleOutputStream;
-use lang\Runtime;
+use io\streams\OutputStreamWriter;
+use unittest\ColorizingListener;
+use unittest\TestListener;
 
 /**
  * Default listener
  * ----------------
  * Only shows details for failed tests. This listener has no options.
  */
-class DefaultListener  implements TestListener, ColorizingListener {
+class DefaultListener implements TestListener, ColorizingListener {
   const OUTPUT_WIDTH= 72;
 
   public $out= null;
@@ -184,14 +183,8 @@ class DefaultListener  implements TestListener, ColorizingListener {
       $result->failureCount(),
       $this->colored ? "\033[0m" : ''
     );
-    $this->out->writeLinef(
-      'Memory used: %.2f kB (%.2f kB peak)',
-      Runtime::getInstance()->memoryUsage() / 1024,
-      Runtime::getInstance()->peakMemoryUsage() / 1024
-    );
-    $this->out->writeLinef(
-      'Time taken: %.3f seconds',
-      $result->elapsed()
-    );
+    foreach ($result->metrics() as $name => $metric) {
+      $this->out->writeLine($name, ': ', $metric());
+    }
   }
 }

--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -184,7 +184,7 @@ class DefaultListener implements TestListener, ColorizingListener {
       $this->colored ? "\033[0m" : ''
     );
     foreach ($result->metrics() as $name => $metric) {
-      $this->out->writeLine($name, ': ', $metric());
+      $this->out->writeLine($name, ': ', $metric->formatted());
     }
   }
 }

--- a/src/main/php/xp/unittest/VerboseListener.class.php
+++ b/src/main/php/xp/unittest/VerboseListener.class.php
@@ -1,9 +1,8 @@
 <?php namespace xp\unittest;
 
-use unittest\TestListener;
-use unittest\TestCase;
 use io\streams\OutputStreamWriter;
-use lang\Runtime;
+use unittest\TestCase;
+use unittest\TestListener;
 
 /**
  * Verbose listener
@@ -134,14 +133,8 @@ class VerboseListener implements TestListener {
       $result->successCount(),
       $result->failureCount()
     );
-    $this->out->writeLinef(
-      '===> Memory used: %.2f kB (%.2f kB peak)',
-      Runtime::getInstance()->memoryUsage() / 1024,
-      Runtime::getInstance()->peakMemoryUsage() / 1024
-    );
-    $this->out->writeLinef(
-      '===> Time taken: %.3f seconds',
-      $result->elapsed()
-    );
+    foreach ($result->metrics() as $name => $metric) {
+      $this->out->writeLine('===> ', $name, ': ', $metric());
+    }
   }
 }

--- a/src/main/php/xp/unittest/VerboseListener.class.php
+++ b/src/main/php/xp/unittest/VerboseListener.class.php
@@ -134,7 +134,7 @@ class VerboseListener implements TestListener {
       $result->failureCount()
     );
     foreach ($result->metrics() as $name => $metric) {
-      $this->out->writeLine('===> ', $name, ': ', $metric());
+      $this->out->writeLine('===> ', $name, ': ', $metric->formatted());
     }
   }
 }

--- a/src/test/php/unittest/tests/MetricsTest.class.php
+++ b/src/test/php/unittest/tests/MetricsTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use lang\Runtime;
 use unittest\TestCase;
 use unittest\TestResult;
 use unittest\metrics\MemoryUsed;
@@ -68,7 +69,10 @@ class MetricsTest extends TestCase {
 
   #[@test]
   public function memory_used() {
-    $t= new MemoryUsed();
-    $this->assertEquals(memory_get_usage(), $t->calculated());
+    $t= new MemoryUsed(newinstance(Runtime::class, [], [
+      'memoryUsage'     => function() { return 6100; },
+      'peakMemoryUsage' => function() { return 9999; },
+    ]));
+    $this->assertEquals(6100, $t->calculated());
   }
 }

--- a/src/test/php/unittest/tests/MetricsTest.class.php
+++ b/src/test/php/unittest/tests/MetricsTest.class.php
@@ -1,0 +1,74 @@
+<?php namespace unittest\tests;
+
+use unittest\TestCase;
+use unittest\TestResult;
+use unittest\metrics\MemoryUsed;
+use unittest\metrics\Metric;
+use unittest\metrics\TimeTaken;
+
+class MetricsTest extends TestCase {
+
+  #[@test]
+  public function formatted_calls_calculate_once() {
+    $metric= new TestMetric(0);
+    $this->assertEquals(['+1', '+1'], [$metric->formatted(), $metric->formatted()]);
+  }
+
+  #[@test]
+  public function formatted_can_refresh_calculation() {
+    $metric= new TestMetric(0);
+    $this->assertEquals(['+1', '+2'], [$metric->formatted(), $metric->formatted(true)]);
+  }
+
+  #[@test]
+  public function calculated_calls_calculate_once() {
+    $metric= new TestMetric(0);
+    $this->assertEquals([1, 1], [$metric->calculated(), $metric->calculated()]);
+  }
+
+  #[@test]
+  public function calculated_can_refresh_calculation() {
+    $metric= new TestMetric(0);
+    $this->assertEquals([1, 2], [$metric->calculated(), $metric->calculated(true)]);
+  }
+
+  #[@test]
+  public function string_representation() {
+    $metric= new TestMetric(6100);
+    $this->assertEquals('unittest.tests.TestMetric<+6101>', $metric->toString());
+  }
+
+  #[@test]
+  public function hash_code() {
+    $metric= new TestMetric(6100);
+    $this->assertEquals('Mba2c5278f196f791a788e7b0d4498ed7', $metric->hashCode());
+  }
+
+  #[@test]
+  public function comparing_to_another_instance() {
+    $this->assertEquals(1, (new TestMetric(0))->compareTo($this));
+  }
+
+  #[@test, @values([
+  #  [0, 0],
+  #  [1, -1],
+  #  [6100, -1],
+  #  [-1, 1],
+  #  [-6100, 1]
+  #])]
+  public function comparing_two_metrics($counter, $expected) {
+    $this->assertEquals($expected, (new TestMetric(0))->compareTo(new TestMetric($counter)));
+  }
+
+  #[@test]
+  public function time_taken() {
+    $t= new TimeTaken(new TestResult());
+    $this->assertEquals(0.0, $t->calculated());
+  }
+
+  #[@test]
+  public function memory_used() {
+    $t= new MemoryUsed();
+    $this->assertEquals(memory_get_usage(), $t->calculated());
+  }
+}

--- a/src/test/php/unittest/tests/TestMetric.class.php
+++ b/src/test/php/unittest/tests/TestMetric.class.php
@@ -1,0 +1,20 @@
+<?php namespace unittest\tests;
+
+use unittest\metrics\Metric;
+
+class TestMetric extends Metric {
+  private $counter;
+
+  /** @param int $counter */
+  public function __construct($counter) { $this->counter= $counter; }
+
+  /** @return void */
+  protected function calculate() { $this->counter++; }
+
+  /** @return var */
+  protected function value() { return $this->counter; }
+
+  /** @return string */
+  protected function format() { return sprintf('+%d', $this->counter); }
+
+}

--- a/src/test/php/unittest/tests/TestResultTest.class.php
+++ b/src/test/php/unittest/tests/TestResultTest.class.php
@@ -111,6 +111,18 @@ class TestResultTest extends TestCase {
     $this->assertNotEquals($this, new TestResult());
   }
 
+  #[@test, @values(['Memory used', 'Time taken'])]
+  public function default_metric($name) {
+    $metrics= (new TestResult())->metrics();
+    $this->assertTrue(isset($metrics[$name]));
+  }
+
+  #[@test, @values(['Tested', function() { return 'Tested'; }])]
+  public function record_metric($metric) {
+    $metric= (new TestResult())->metric('Test', $metric)->metrics()['Test'];
+    $this->assertEquals('Tested', $metric());
+  }
+
   /** @deprecated */
   #[@test]
   public function set() {

--- a/src/test/php/unittest/tests/TestResultTest.class.php
+++ b/src/test/php/unittest/tests/TestResultTest.class.php
@@ -7,6 +7,7 @@ use unittest\TestError;
 use unittest\TestResult;
 use unittest\TestSkipped;
 use unittest\TestSuccess;
+use unittest\metrics\Metric;
 
 class TestResultTest extends TestCase {
 
@@ -117,10 +118,14 @@ class TestResultTest extends TestCase {
     $this->assertTrue(isset($metrics[$name]));
   }
 
-  #[@test, @values(['Tested', function() { return 'Tested'; }])]
-  public function record_metric($metric) {
-    $metric= (new TestResult())->metric('Test', $metric)->metrics()['Test'];
-    $this->assertEquals('Tested', $metric());
+  #[@test]
+  public function record_metric() {
+    $metric= newinstance(Metric::class, [], [
+      'calculate' => function() {  },
+      'value'     => function() { return 6100; },
+      'format'    => function() { return 'Test'; }
+    ]);
+    $this->assertEquals($metric, (new TestResult())->metric('Test', $metric)->metrics()['Test']);
   }
 
   /** @deprecated */


### PR DESCRIPTION
Implements #33 

## Usage

Inside a listener's `testRunFinished()` method, call the *metric()* method. Here's an example from the coverage library:

```php
class CoveredLines extends Metric {
  private $coverage, $executed, $executable;

  public function __construct($coverage) {
    $this->coverage= $coverage;
  }

  protected function calculate() {
    $report= $this->coverage->getReport();
    $this->executed= $report->getNumExecutedLines();
    $this->executable= $report->getNumExecutableLines();
  }

  protected function format() {
    $percent= $this->executed / $this->executable * 100;
    return sprintf(
      "%s%.2f%%\033[0m lines covered (%d/%d)",
      $percent < 50.0 ? "\033[31;1m" : ($percent < 90.0 ? "\033[33;1m" : "\033[32;1m"),
      $percent,
      $this->executed,
      $this->executable
    );
  }

  protected function value() {
    return $this->executed / $this->executable * 100;
  }
}

$result->metric('Coverage', new CoveredLines($this->coverage));
```

## Example

![image](https://user-images.githubusercontent.com/696742/45598912-3f914580-b9e3-11e8-91bc-ee0f66983825.png)
