### PR TITLE
Baseless, single-instance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ Unittests for the XP Framework
 
 Writing a test
 --------------
-Tests reside inside a testcase class and are annotated with the `@test` annotation.
+Tests reside inside a class and are annotated with the `@test` annotation.
 
 ```php
-use unittest\TestCase;
+use unittest\Assert;
 
-class CalculatorTest extends TestCase {
+class CalculatorTest {
 
   #[@test]
   public function addition() {
-    $this->assertEquals(2, 1 + 1);
+    Assert::equals(2, 1 + 1);
   }
 }
 ```
@@ -33,7 +33,7 @@ $ xp test CalculatorTest
 [.]
 
 ♥: 1/1 run (0 skipped), 1 succeeded, 0 failed
-Memory used: 1173.51 kB (1307.40 kB peak)
+Memory used: 1672.58 kB (1719.17 kB peak)
 Time taken: 0.000 seconds
 ```
 
@@ -42,46 +42,46 @@ Assertion methods
 The unittest package provides the following six assertion methods:
 
 ```php
-public void assertEquals(var $expected, var $actual, [string $error= "equals"])
-public void assertNotEquals(var $expected, var $actual, [string $error= "!equals"])
-public void assertTrue(var $actual, [string $error= "==="])
-public void assertFalse(var $actual, [string $error= "==="])
-public void assertNull(var $actual, [string $error= "==="])
-public void assertInstanceOf(var $type, var $actual, [string $error= "instanceof"])
+public abstract class unittest.Assert {
+  public static void equals(var $expected, var $actual, string $error)
+  public static void notEquals(var $expected, var $actual, string $error)
+  public static void true(var $actual, string $error)
+  public static void false(var $actual, string $error)
+  public static void null(var $actual, string $error)
+  public static void instance(string|lang.Type $type, var $actual, string $error)
+}
 ```
-
-To manually skip a test, call `$this->fail('Reason')` anywhere inside your test code.
 
 *If you need more than that, you can use [xp-forge/assert](https://github.com/xp-forge/assert) on top of this library.*
 
 Setup and teardown
 ------------------
-In order to run a method before and after every test, overwrite the base class' `setUp()` and `tearDown()` methods:
+In order to run a method before and after the tests are run, annotate methods with the `@before` and `@after` annotations:
 
 ```php
-use unittest\TestCase;
+use unittest\Assert;
 
-class CalculatorTest extends TestCase {
+class CalculatorTest {
   private $fixture;
 
-  /** @return void */
-  public function setUp() {
+  #[@before]
+  public function newFixture() {
     $this->fixture= new Calculator();
   }
 
-  /** @return void */
-  public function tearDown() {
+  #[@after]
+  public function cleanUp() {
     unset($this->fixture);
   }
 
   #[@test]
   public function addition() {
-    $this->assertEquals(2, $this->fixture->add(1, 1));
+    Assert::equals(2, $this->fixture->add(1, 1));
   }
 }
 ```
 
-*Note: The `unset` above isn't really necessary, a fresh instance of the testcase class is created before every run and disposed thereafter, thus PHP's garbage collection takes care of freeing all members.*
+*Note: All test methods are run with the same instance of CalculatorTest!*
 
 Expected exceptions
 -------------------
@@ -89,9 +89,8 @@ The `@expect` annotation is a shorthand for catching exceptions and verifying th
 
 ```php
 use lang\IllegalArgumentException;
-use unittest\TestCase;
 
-class CalculatorTest extends TestCase {
+class CalculatorTest {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function cannot_divide_by_zero() {
@@ -105,9 +104,7 @@ Ignoring tests
 The `@ignore` annotation can be used to ignore tests. This can be necessary as a temporary measure or when overriding a test base class and not wanting to run one of its methods.
 
 ```php
-use unittest\TestCase;
-
-class EncodingTest extends TestCase {
+class EncodingTest {
 
   #[@test, @ignore('Does not work with all iconv implementations')]
   public function transliteration() {
@@ -116,17 +113,14 @@ class EncodingTest extends TestCase {
 }
 ```
 
-To manually skip a test, call `$this->skip('Reason')` anywhere inside your test code.
-
 Parameterization
 -----------------
 The `@values` annotation can be used to run a test with a variety of values which are passed as parameters.
 
 ```php
 use lang\IllegalArgumentException;
-use unittest\TestCase;
 
-class CalculatorTest extends TestCase {
+class CalculatorTest {
 
   #[@test, @expect(IllegalArgumentException::class), @values([1, 0, -1])]
   public function cannot_divide_by_zero($dividend) {
@@ -145,11 +139,9 @@ To execute code before and after tests, test actions can be used. The unittest l
 * `unittest.actions.VerifyThat(function(): var|string $callable)` - Runs the given function, verifying it neither raises an exception nor return a false value.
 
 ```php
-use unittest\actions\IsPlatform;
-use unittest\actions\VerifyThat;
-use unittest\TestCase;
+use unittest\actions\{IsPlatform, VerifyThat};
 
-class FileSystemTest extends TestCase {
+class FileSystemTest {
 
   #[@test, @action(new IsPlatform('!WIN'))
   public function not_run_on_windows() {

--- a/src/main/php/unittest/Assert.class.php
+++ b/src/main/php/unittest/Assert.class.php
@@ -1,8 +1,14 @@
 <?php namespace unittest;
 
+use lang\Type;
 use util\Objects;
 
-class Assert {
+/**
+ * Default assertion set
+ *
+ * @test  xp://unittest.tests.AssertTest
+ */
+abstract class Assert {
 
   /**
    * Assert that two values are equal
@@ -15,6 +21,74 @@ class Assert {
   public static function equals($expected, $actual, $error= 'equals') {
     if (!Objects::equal($expected, $actual)) {
       throw new AssertionFailedError(new ComparisonFailedMessage($error, $expected, $actual));
+    }
+  }
+
+  /**
+   * Assert that two values are not equal
+   *
+   * @param  var expected
+   * @param  var actual
+   * @param  string error default 'equal'
+   * @return void
+   */
+  public static function notEquals($expected, $actual, $error= '!equals') {
+    if (Objects::equal($expected, $actual)) {
+      throw new AssertionFailedError(new ComparisonFailedMessage($error, $expected, $actual));
+    }
+  }
+
+  /**
+   * Assert that a value is true
+   *
+   * @param  var $actual
+   * @param  string $error default '==='
+   * @return void
+   */
+  public static function true($actual, $error= '===') {
+    if (true !== $actual) {
+      throw new AssertionFailedError(new ComparisonFailedMessage($error, true, $actual));
+    }
+  }
+  
+  /**
+   * Assert that a value is false
+   *
+   * @param  var $actual
+   * @param  string $error default '==='
+   * @return void
+   */
+  public static function false($actual, $error= '===') {
+    if (false !== $actual) {
+      throw new AssertionFailedError(new ComparisonFailedMessage($error, false, $actual));
+    }
+  }
+
+  /**
+   * Assert that a value's type is null
+   *
+   * @param  var $actual
+   * @param  string $error default '==='
+   * @return void
+   */
+  public static function null($actual, $error= '===') {
+    if (null !== $actual) {
+      throw new AssertionFailedError(new ComparisonFailedMessage($error, null, $actual));
+    }
+  }
+
+  /**
+   * Assert that a given object is a subclass of a specified class
+   *
+   * @param  string|lang.Type $type
+   * @param  var $actual
+   * @param  string $error default 'instanceof'
+   * @return void
+   */
+  public static function instance($type, $actual, $error= 'instanceof') {
+    $t= $type instanceof Type ? $type : Type::forName($type);
+    if (!$t->isInstance($actual)) {
+      throw new AssertionFailedError(new ComparisonFailedMessage($error, $t->getName(), typeof($actual)->getName()));
     }
   }
 }

--- a/src/main/php/unittest/Assert.class.php
+++ b/src/main/php/unittest/Assert.class.php
@@ -1,0 +1,20 @@
+<?php namespace unittest;
+
+use util\Objects;
+
+class Assert {
+
+  /**
+   * Assert that two values are equal
+   *
+   * @param  var $expected
+   * @param  var $actual
+   * @param  string $error
+   * @return void
+   */
+  public static function equals($expected, $actual, $error= 'equals') {
+    if (!Objects::equal($expected, $actual)) {
+      throw new AssertionFailedError(new ComparisonFailedMessage($error, $expected, $actual));
+    }
+  }
+}

--- a/src/main/php/unittest/AssertionFailedError.class.php
+++ b/src/main/php/unittest/AssertionFailedError.class.php
@@ -32,7 +32,7 @@ class AssertionFailedError extends TestAborted {
   public function type() { return 'testFailed'; }
 
   /** @return unittest.TestOutcome */
-  public function outcome(TestCase $test, Timer $timer) {
+  public function outcome(Test $test, Timer $timer) {
     return new TestAssertionFailed($test, $this, $timer->elapsedTime());
   }
 

--- a/src/main/php/unittest/IgnoredBecause.class.php
+++ b/src/main/php/unittest/IgnoredBecause.class.php
@@ -20,7 +20,7 @@ class IgnoredBecause extends TestAborted {
   public function type() { return 'testSkipped'; }
 
   /** @return unittest.TestOutcome */
-  public function outcome(TestCase $test, Timer $timer) {
+  public function outcome(Test $test, Timer $timer) {
     return new TestNotRun($test, $this, $timer->elapsedTime());
   }
 

--- a/src/main/php/unittest/IgnoredBecause.class.php
+++ b/src/main/php/unittest/IgnoredBecause.class.php
@@ -7,15 +7,6 @@ use util\profiling\Timer;
  */
 class IgnoredBecause extends TestAborted {
     
-  /**
-   * Constructor
-   *
-   * @param  string $value The annotation value
-   */
-  public function __construct($value) {
-    parent::__construct($value ? (string)$value : 'n/a');
-  }
-
   /** @return string */
   public function type() { return 'testSkipped'; }
 

--- a/src/main/php/unittest/PrerequisitesFailedError.class.php
+++ b/src/main/php/unittest/PrerequisitesFailedError.class.php
@@ -13,7 +13,7 @@ class PrerequisitesFailedError extends PrerequisitesNotMetError {
   public function type() { return 'testFailed'; }
 
   /** @return unittest.TestOutcome */
-  public function outcome(TestCase $test, Timer $timer) {
+  public function outcome(Test $test, Timer $timer) {
     return new TestPrerequisitesFailed($test, $this, $timer->elapsedTime());
   }
 }

--- a/src/main/php/unittest/PrerequisitesNotMetError.class.php
+++ b/src/main/php/unittest/PrerequisitesNotMetError.class.php
@@ -28,7 +28,7 @@ class PrerequisitesNotMetError extends TestAborted {
   public function type() { return 'testSkipped'; }
 
   /** @return unittest.TestOutcome */
-  public function outcome(TestCase $test, Timer $timer) {
+  public function outcome(Test $test, Timer $timer) {
     return new TestPrerequisitesNotMet($test, $this, $timer->elapsedTime());
   }
 

--- a/src/main/php/unittest/Target.class.php
+++ b/src/main/php/unittest/Target.class.php
@@ -1,9 +1,0 @@
-<?php namespace unittest;
-
-class Target {
-
-  public function __construct($name, $instance) {
-    $this->name= $name;
-    $this->instance= $instance;
-  }
-}

--- a/src/main/php/unittest/Target.class.php
+++ b/src/main/php/unittest/Target.class.php
@@ -1,0 +1,9 @@
+<?php namespace unittest;
+
+class Target {
+
+  public function __construct($name, $instance) {
+    $this->name= $name;
+    $this->instance= $instance;
+  }
+}

--- a/src/main/php/unittest/Test.class.php
+++ b/src/main/php/unittest/Test.class.php
@@ -1,13 +1,6 @@
 <?php namespace unittest;
 
-class Test {
-  public $instance, $method, $actions;
-
-  public function __construct($instance, $method, $actions= []) {
-    $this->instance= $instance;
-    $this->method= $method;
-    $this->actions= $actions;
-  }
+interface Test {
 
   /**
    * Get this test target's name
@@ -15,36 +8,8 @@ class Test {
    * @param  bool $compound whether to use compound format
    * @return string
    */
-  public function getName($compound= false) {
-    return $compound ? nameof($this->instance).'::'.$this->method->getName() : $this->method->getName();
-  }
+  public function getName($compound= false);
 
-  public function hashCode() {
-    if ($this->instance instanceof TestCase) {
-      return $this->instance->hashCode();
-    } else {
-      return md5(get_class($this->instance).':'.$this->method->getName());
-    }
-  }
+  public function hashCode();
 
-  /** @deprecated */
-  private $case= null;
-
-  /** @deprecated */
-  public function asCase() {
-    if (null === $this->case) {
-      if ($this->instance instanceof TestCase) {
-        $this->case= $this->instance;
-      } else {
-        $name= $this->method->getName();
-        $instance= $this->instance;
-        $this->case= newinstance(TestCase::class, [$name], [
-          $name => function() use($instance, $name) {
-            return $instance->{$name}();
-          }
-        ]);
-      }
-    }
-    return $this->case;
-  }
 }

--- a/src/main/php/unittest/Test.class.php
+++ b/src/main/php/unittest/Test.class.php
@@ -1,6 +1,7 @@
 <?php namespace unittest;
 
 use lang\Value;
+use lang\XPClass;
 
 abstract class Test implements Value {
 
@@ -18,6 +19,60 @@ abstract class Test implements Value {
    * @return string
    */
   public abstract function hashCode();
+
+  public function variations() {
+
+    // Check for @values
+    if ($this->method->hasAnnotation('values')) {
+      foreach ($this->valuesFor($this->instance, $this->method->getAnnotation('values')) as $args) {
+        yield new TestVariation($this, is_array($args) ? $args : [$args]);
+      }
+    } else {
+      yield $this;
+    }
+  }
+
+  /**
+   * Returns values
+   *
+   * @param  object $test
+   * @param  var $annotation
+   * @return var values a traversable structure
+   */
+  protected function valuesFor($test, $annotation) {
+    if (!is_array($annotation)) {               // values("source")
+      $source= $annotation;
+      $args= [];
+    } else if (isset($annotation['map'])) {     // values(map= ["test" => true, ...])
+      $values= [];
+      foreach ($annotation['map'] as $key => $value) {
+        $values[]= [$key, $value];
+      }
+      return $values;
+    } else if (isset($annotation['source'])) {  // values(source= "src" [, args= ...])
+      $source= $annotation['source'];
+      $args= isset($annotation['args']) ? $annotation['args'] : [];
+    } else {                                    // values([1, 2, 3])
+      return $annotation;
+    }
+
+    // Route "ClassName::methodName" -> static method of the given class,
+    // "self::method" -> static method of the test class, and "method" 
+    // -> the run test's instance method
+    if (false === ($p= strpos($source, '::'))) {
+      return typeof($test)->getMethod($source)->setAccessible(true)->invoke($test, $args);
+    }
+
+    $ref= substr($source, 0, $p);
+    if ('self' === $ref) {
+      $class= typeof($test);
+    } else if (strstr($ref, '.')) {
+      $class= XPClass::forName($ref);
+    } else {
+      $class= new XPClass($ref);
+    }
+    return $class->getMethod(substr($source, $p+ 2))->invoke(null, $args);
+  }
 
   /**
    * Creates a string representation of this testcase

--- a/src/main/php/unittest/Test.class.php
+++ b/src/main/php/unittest/Test.class.php
@@ -1,0 +1,49 @@
+<?php namespace unittest;
+
+class Test {
+  public $instance, $method;
+
+  public function __construct($instance, $method) {
+    $this->instance= $instance;
+    $this->method= $method;
+  }
+
+  /**
+   * Get this test target's name
+   *
+   * @param  bool $compound whether to use compound format
+   * @return string
+   */
+  public function getName($compound= false) {
+    return $compound ? nameof($this->instance).'::'.$this->method->getName() : $this->method->getName();
+  }
+
+  public function hashCode() {
+    if ($this->instance instanceof TestCase) {
+      return $this->instance->hashCode();
+    } else {
+      return md5(get_class($this->instance).':'.$this->method->getName());
+    }
+  }
+
+  /** @deprecated */
+  private $case= null;
+
+  /** @deprecated */
+  public function asCase() {
+    if (null === $this->case) {
+      if ($this->instance instanceof TestCase) {
+        $this->case= $this->instance;
+      } else {
+        $name= $this->method->getName();
+        $instance= $this->instance;
+        $this->case= newinstance(TestCase::class, [$name], [
+          $name => function() use($instance, $name) {
+            return $instance->{$name}();
+          }
+        ]);
+      }
+    }
+    return $this->case;
+  }
+}

--- a/src/main/php/unittest/Test.class.php
+++ b/src/main/php/unittest/Test.class.php
@@ -1,15 +1,40 @@
 <?php namespace unittest;
 
-interface Test {
+use lang\Value;
+
+abstract class Test implements Value {
 
   /**
-   * Get this test target's name
+   * Get this test's name
    *
    * @param  bool $compound whether to use compound format
    * @return string
    */
-  public function getName($compound= false);
+  public abstract function getName($compound= false);
 
-  public function hashCode();
+  /**
+   * Creates a hashcode of this testcase
+   *
+   * @return string
+   */
+  public abstract function hashCode();
 
+  /**
+   * Creates a string representation of this testcase
+   *
+   * @return  string
+   */
+  public function toString() {
+    return nameof($this).'<'.$this->getName(true).'>';
+  }
+
+  /**
+   * Comparison
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->getName(true), $value->getName(true)) : 1;
+  }
 }

--- a/src/main/php/unittest/Test.class.php
+++ b/src/main/php/unittest/Test.class.php
@@ -29,7 +29,7 @@ abstract class Test implements Value {
 
   /** @return ?string */
   public function ignored() {
-    return $this->method->hasAnnotation('ignore') ? ($this->method->getAnnotation('ignore') ?: '(w/o reason)') : null;
+    return $this->method->hasAnnotation('ignore') ? ($this->method->getAnnotation('ignore') ?: '(n/a)') : null;
   }
 
   /** @return ?int */

--- a/src/main/php/unittest/Test.class.php
+++ b/src/main/php/unittest/Test.class.php
@@ -1,11 +1,12 @@
 <?php namespace unittest;
 
 class Test {
-  public $instance, $method;
+  public $instance, $method, $actions;
 
-  public function __construct($instance, $method) {
+  public function __construct($instance, $method, $actions= []) {
     $this->instance= $instance;
     $this->method= $method;
+    $this->actions= $actions;
   }
 
   /**

--- a/src/main/php/unittest/TestAborted.class.php
+++ b/src/main/php/unittest/TestAborted.class.php
@@ -18,10 +18,10 @@ abstract class TestAborted extends \lang\XPException {
   /**
    * Returns the outcome class
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  util.profiling.Timer $timer
    * @return unittest.TestOutcome
    */ 
-  public abstract function outcome(TestCase $test, Timer $timer);
+  public abstract function outcome(Test $test, Timer $timer);
 
 }

--- a/src/main/php/unittest/TestAction.class.php
+++ b/src/main/php/unittest/TestAction.class.php
@@ -1,28 +1,23 @@
 <?php namespace unittest;
 
-/**
- * Test action
- *
- * @see   xp://unittest.TestCase
- */
 interface TestAction {
 
   /**
    * This method gets invoked before a test method is invoked, and before
    * the setUp() method is called.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    * @return void
    * @throws unittest.PrerequisitesNotMetError
    */
-  public function beforeTest(TestCase $t);
+  public function beforeTest(Test $t);
 
   /**
    * This method gets invoked after the test method is invoked and regard-
    * less of its outcome, after the tearDown() call has run.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    * @return void
    */
-  public function afterTest(TestCase $t);
+  public function afterTest(Test $t);
 }

--- a/src/main/php/unittest/TestAssertionFailed.class.php
+++ b/src/main/php/unittest/TestAssertionFailed.class.php
@@ -10,11 +10,11 @@ class TestAssertionFailed extends TestFailure {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  unittest.AssertionFailedError|unittest.AssertionFailedMessage|string $reason
    * @param  double $elapsed
    */
-  public function __construct(TestCase $test, $reason, $elapsed) {
+  public function __construct(Test $test, $reason, $elapsed) {
     parent::__construct($test, $elapsed);
     $this->reason= $reason instanceof AssertionFailedError ? $reason : new AssertionFailedError($reason);
   }

--- a/src/main/php/unittest/TestCaseInstance.class.php
+++ b/src/main/php/unittest/TestCaseInstance.class.php
@@ -2,7 +2,7 @@
 
 use lang\Throwable;
 
-class TestClassInstance extends Test {
+class TestCaseInstance extends Test {
 
   public function __construct($instance, $method= null, $actions= []) {
     parent::__construct($instance, $method ?: typeof($instance)->getMethod($instance->name), $actions);

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -55,4 +55,12 @@ class TestClass extends TestGroup {
       yield $constructor->newInstance(array_merge([$name], $this->arguments));
     }
   }
+
+  /** @return iterable */
+  public function targets() {
+    $constructor= $this->class->getConstructor();
+    foreach ($this->testMethods as $name) {
+      yield new Target($name, $constructor->newInstance(array_merge([$name], $this->arguments)));
+    }
+  }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -61,7 +61,7 @@ class TestClass extends TestGroup {
   public function targets() {
     $constructor= $this->class->getConstructor();
     foreach ($this->tests as $name => $method) {
-      yield new TestClassInstance(
+      yield new TestCaseInstance(
         $constructor->newInstance(array_merge([$name], $this->arguments)),
         $method,
         array_merge($this->actions, iterator_to_array($this->actionsFor($method, TestAction::class)))

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -60,10 +60,7 @@ class TestClass extends TestGroup {
   public function targets() {
     $constructor= $this->class->getConstructor();
     foreach ($this->testMethods as $name) {
-      yield new Test(
-        $constructor->newInstance(array_merge([$name], $this->arguments)),
-        $this->class->getMethod($name)
-      );
+      yield new TestClassInstance($constructor->newInstance(array_merge([$name], $this->arguments)));
     }
   }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -60,7 +60,10 @@ class TestClass extends TestGroup {
   public function targets() {
     $constructor= $this->class->getConstructor();
     foreach ($this->testMethods as $name) {
-      yield new Target($name, $constructor->newInstance(array_merge([$name], $this->arguments)));
+      yield new Test(
+        $constructor->newInstance(array_merge([$name], $this->arguments)),
+        $this->class->getMethod($name)
+      );
     }
   }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -5,8 +5,8 @@ use util\NoSuchElementException;
 use util\Objects;
 
 class TestClass extends TestGroup {
-  private $class, $arguments;
-  private $testMethods= [];
+  private $class, $actions, $arguments;
+  private $tests= [];
 
   static function __static() { }
 
@@ -30,15 +30,16 @@ class TestClass extends TestGroup {
         if (self::$base->hasMethod($name)) {
           throw $this->cannotOverride($method);
         }
-        $this->testMethods[]= $name;
+        $this->tests[$name]= $method;
       }
     }
 
-    if (empty($this->testMethods)) {
+    if (empty($this->tests)) {
       throw new NoSuchElementException('No tests found in '.$class->getName());
     }
 
     $this->class= $class;
+    $this->actions= iterator_to_array($this->actionsFor($class, TestAction::class));
     $this->arguments= (array)$arguments;
   }
 
@@ -46,12 +47,12 @@ class TestClass extends TestGroup {
   public function type() { return $this->class; }
 
   /** @return int */
-  public function numTests() { return sizeof($this->testMethods); }
+  public function numTests() { return sizeof($this->tests); }
 
-  /** @return php.Generator */
+  /** @return iterable */
   public function tests() {
     $constructor= $this->class->getConstructor();
-    foreach ($this->testMethods as $name) {
+    foreach ($this->tests as $name => $_) {
       yield $constructor->newInstance(array_merge([$name], $this->arguments));
     }
   }
@@ -59,8 +60,12 @@ class TestClass extends TestGroup {
   /** @return iterable */
   public function targets() {
     $constructor= $this->class->getConstructor();
-    foreach ($this->testMethods as $name) {
-      yield new TestClassInstance($constructor->newInstance(array_merge([$name], $this->arguments)));
+    foreach ($this->tests as $name => $method) {
+      yield new TestClassInstance(
+        $constructor->newInstance(array_merge([$name], $this->arguments)),
+        $method,
+        array_merge($this->actions, iterator_to_array($this->actionsFor($method, TestAction::class)))
+      );
     }
   }
 }

--- a/src/main/php/unittest/TestClass.class.php
+++ b/src/main/php/unittest/TestClass.class.php
@@ -52,14 +52,6 @@ class TestClass extends TestGroup {
   /** @return iterable */
   public function tests() {
     $constructor= $this->class->getConstructor();
-    foreach ($this->tests as $name => $_) {
-      yield $constructor->newInstance(array_merge([$name], $this->arguments));
-    }
-  }
-
-  /** @return iterable */
-  public function targets() {
-    $constructor= $this->class->getConstructor();
     foreach ($this->tests as $name => $method) {
       yield new TestCaseInstance(
         $constructor->newInstance(array_merge([$name], $this->arguments)),

--- a/src/main/php/unittest/TestClassInstance.class.php
+++ b/src/main/php/unittest/TestClassInstance.class.php
@@ -2,7 +2,7 @@
 
 use lang\Throwable;
 
-class TestClassInstance implements Test {
+class TestClassInstance extends Test {
   public $instance, $method;
 
   public function __construct($instance) {

--- a/src/main/php/unittest/TestClassInstance.class.php
+++ b/src/main/php/unittest/TestClassInstance.class.php
@@ -1,0 +1,63 @@
+<?php namespace unittest;
+
+use lang\Throwable;
+
+class TestClassInstance implements Test {
+  public $instance, $method;
+
+  public function __construct($instance) {
+    $this->instance= $instance;
+    $this->method= typeof($instance)->getMethod($instance->name);
+  }
+
+  /**
+   * Invoke a block, wrap PHP5 and PHP7 native base exceptions in lang.Error
+   *
+   * @param  string $method
+   * @return void
+   */
+  private function invoke($method) {
+    try {
+      $this->instance->{$method}();
+    } catch (Throwable $e) {
+      throw $e;
+    } catch (\Exception $e) {
+      throw Throwable::wrap($e);
+    } catch (\Throwable $e) {
+      throw Throwable::wrap($e);
+    }
+  }
+
+  /**
+   * Runs this testcase
+   *
+   * @param  var[] $args
+   * @return void
+   * @throws lang.Throwable
+   */
+  public function run($args) {
+    try {
+      $this->invoke('setUp');
+      $this->method->invoke($this->instance, $args);
+    } finally {
+      $this->invoke('tearDown');
+    }
+  }
+
+  /**
+   * Get this test target's name
+   *
+   * @param  bool $compound whether to use compound format
+   * @return string
+   */
+  public function getName($compound= false) {
+    return $this->instance->getName($compound);
+  }
+
+  public function hashCode() {
+    return $this->instance->hashCode();
+  }
+
+  /** @deprecated */
+  public function asCase() { return $this->instance; }
+}

--- a/src/main/php/unittest/TestClassInstance.class.php
+++ b/src/main/php/unittest/TestClassInstance.class.php
@@ -3,11 +3,12 @@
 use lang\Throwable;
 
 class TestClassInstance extends Test {
-  public $instance, $method;
+  public $instance, $method, $actions;
 
-  public function __construct($instance) {
+  public function __construct($instance, $method= null, $actions= []) {
     $this->instance= $instance;
-    $this->method= typeof($instance)->getMethod($instance->name);
+    $this->method= $method ?: typeof($instance)->getMethod($instance->name);
+    $this->actions= $actions;
   }
 
   /** @return [:var] */

--- a/src/main/php/unittest/TestClassInstance.class.php
+++ b/src/main/php/unittest/TestClassInstance.class.php
@@ -10,6 +10,15 @@ class TestClassInstance extends Test {
     $this->method= typeof($instance)->getMethod($instance->name);
   }
 
+  /** @return [:var] */
+  public function annotations() {
+    $return= [];
+    foreach ($this->method->getAnnotations() as $name => $value) {
+      $return[$name]= [$value];
+    }
+    return $return;
+  }
+
   /**
    * Invoke a block, wrap PHP5 and PHP7 native base exceptions in lang.Error
    *
@@ -54,6 +63,7 @@ class TestClassInstance extends Test {
     return $this->instance->getName($compound);
   }
 
+  /** @return string */
   public function hashCode() {
     return $this->instance->hashCode();
   }

--- a/src/main/php/unittest/TestClassInstance.class.php
+++ b/src/main/php/unittest/TestClassInstance.class.php
@@ -57,7 +57,4 @@ class TestClassInstance implements Test {
   public function hashCode() {
     return $this->instance->hashCode();
   }
-
-  /** @deprecated */
-  public function asCase() { return $this->instance; }
 }

--- a/src/main/php/unittest/TestClassInstance.class.php
+++ b/src/main/php/unittest/TestClassInstance.class.php
@@ -3,21 +3,9 @@
 use lang\Throwable;
 
 class TestClassInstance extends Test {
-  public $instance, $method, $actions;
 
   public function __construct($instance, $method= null, $actions= []) {
-    $this->instance= $instance;
-    $this->method= $method ?: typeof($instance)->getMethod($instance->name);
-    $this->actions= $actions;
-  }
-
-  /** @return [:var] */
-  public function annotations() {
-    $return= [];
-    foreach ($this->method->getAnnotations() as $name => $value) {
-      $return[$name]= [$value];
-    }
-    return $return;
+    parent::__construct($instance, $method ?: typeof($instance)->getMethod($instance->name), $actions);
   }
 
   /**

--- a/src/main/php/unittest/TestError.class.php
+++ b/src/main/php/unittest/TestError.class.php
@@ -12,11 +12,11 @@ class TestError extends TestFailure {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  lang.Throwable $reason
    * @param  double $elapsed
    */
-  public function __construct(TestCase $test, Throwable $reason, $elapsed) {
+  public function __construct(Test $test, Throwable $reason, $elapsed) {
     parent::__construct($test, $elapsed);
     $this->reason= $reason;
   }

--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -27,20 +27,21 @@ abstract class TestGroup {
   }
 
   /**
-   * Returns TestClassActions for a given class
+   * Returns actions for a given class
    *
    * @param  lang.XPClass $class
+   * @param  string $kind
    * @return iterable
    */
-  private function actionsFor($class) {
+  protected function actionsFor($class, $kind) {
     if ($class->hasAnnotation('action')) {
       $action= $class->getAnnotation('action');
       if (is_array($action)) {
         foreach ($action as $a) {
-          if ($a instanceof TestClassAction) yield $a;
+          if ($a instanceof $kind) yield $a;
         }
       } else {
-        if ($action instanceof TestClassAction) yield $action;
+        if ($action instanceof $kind) yield $action;
       }
     }
   }
@@ -83,7 +84,7 @@ abstract class TestGroup {
     } while ($it->valid());
 
     $class= $this->type();
-    foreach ($this->actionsFor($class) as $action) {
+    foreach ($this->actionsFor($class, TestClassAction::class) as $action) {
       $action->beforeTestClass($class);
     }
   }
@@ -95,7 +96,7 @@ abstract class TestGroup {
    */
   public function after() {
     $class= $this->type();
-    foreach ($this->actionsFor($class) as $action) {
+    foreach ($this->actionsFor($class, TestClassAction::class) as $action) {
       $action->afterTestClass($class);
     }
 

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -37,5 +37,10 @@ class TestInstance extends TestGroup {
   public function tests() { yield $this->instance; }
 
   /** @return iterable */
-  public function targets() { yield new Target($this->instance->name, $this->instance); }
+  public function targets() {
+    yield new Test(
+      $this->instance,
+      typeof($this->instance)->getMethod($this->instance->name)
+    );
+  }
 }

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -35,4 +35,7 @@ class TestInstance extends TestGroup {
 
   /** @return iterable */
   public function tests() { yield $this->instance; }
+
+  /** @return iterable */
+  public function targets() { yield new Target($this->instance->name, $this->instance); }
 }

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -37,10 +37,5 @@ class TestInstance extends TestGroup {
   public function tests() { yield $this->instance; }
 
   /** @return iterable */
-  public function targets() {
-    yield new Test(
-      $this->instance,
-      typeof($this->instance)->getMethod($this->instance->name)
-    );
-  }
+  public function targets() { yield new TestClassInstance($this->instance); }
 }

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -26,7 +26,7 @@ class TestInstance extends TestGroup {
     }
 
     $this->instance= $instance;
-    $this->target= new TestClassInstance($instance, $method, array_merge(
+    $this->target= new TestCaseInstance($instance, $method, array_merge(
       iterator_to_array($this->actionsFor($class, TestAction::class)),
       iterator_to_array($this->actionsFor($method, TestAction::class))
     ));

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -3,7 +3,7 @@
 use lang\MethodNotImplementedException;
 
 class TestInstance extends TestGroup {
-  private $instance;
+  private $instance, $target;
 
   static function __static() { }
 
@@ -20,11 +20,16 @@ class TestInstance extends TestGroup {
       throw new MethodNotImplementedException('Test method does not exist', $instance->name);
     }
 
+    $method= $class->getMethod($instance->name);
     if (self::$base->hasMethod($instance->name)) {
-      throw $this->cannotOverride($class->getMethod($instance->name));
+      throw $this->cannotOverride($method);
     }
 
     $this->instance= $instance;
+    $this->target= new TestClassInstance($instance, $method, array_merge(
+      iterator_to_array($this->actionsFor($class, TestAction::class)),
+      iterator_to_array($this->actionsFor($method, TestAction::class))
+    ));
   }
 
   /** @return lang.XPClass */
@@ -37,5 +42,5 @@ class TestInstance extends TestGroup {
   public function tests() { yield $this->instance; }
 
   /** @return iterable */
-  public function targets() { yield new TestClassInstance($this->instance); }
+  public function targets() { yield $this->target; }
 }

--- a/src/main/php/unittest/TestInstance.class.php
+++ b/src/main/php/unittest/TestInstance.class.php
@@ -3,7 +3,7 @@
 use lang\MethodNotImplementedException;
 
 class TestInstance extends TestGroup {
-  private $instance, $target;
+  private $target;
 
   static function __static() { }
 
@@ -25,7 +25,6 @@ class TestInstance extends TestGroup {
       throw $this->cannotOverride($method);
     }
 
-    $this->instance= $instance;
     $this->target= new TestCaseInstance($instance, $method, array_merge(
       iterator_to_array($this->actionsFor($class, TestAction::class)),
       iterator_to_array($this->actionsFor($method, TestAction::class))
@@ -33,14 +32,11 @@ class TestInstance extends TestGroup {
   }
 
   /** @return lang.XPClass */
-  public function type() { return typeof($this->instance); }
+  public function type() { return typeof($this->target->instance); }
 
   /** @return int */
   public function numTests() { return 1; }
 
   /** @return iterable */
-  public function tests() { yield $this->instance; }
-
-  /** @return iterable */
-  public function targets() { yield $this->target; }
+  public function tests() { yield $this->target; }
 }

--- a/src/main/php/unittest/TestListener.class.php
+++ b/src/main/php/unittest/TestListener.class.php
@@ -12,35 +12,35 @@ interface TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.Test $test
    */
-  public function testStarted(TestCase $case);
+  public function testStarted(Test $test);
 
   /**
    * Called when a test fails.
    *
-   * @param   unittest.TestFailure failure
+   * @param  unittest.TestFailure $failure
    */
   public function testFailed(TestFailure $failure);
 
   /**
    * Called when a test errors.
    *
-   * @param   unittest.TestFailure error
+   * @param  unittest.TestFailure $error
    */
   public function testError(TestError $error);
 
   /**
    * Called when a test raises warnings.
    *
-   * @param   unittest.TestWarning warning
+   * @param  unittest.TestWarning $warning
    */
   public function testWarning(TestWarning $warning);
   
   /**
    * Called when a test finished successfully.
    *
-   * @param   unittest.TestSuccess success
+   * @param  unittest.TestSuccess $success
    */
   public function testSucceeded(TestSuccess $success);
 
@@ -48,30 +48,30 @@ interface TestListener {
    * Called when a test is not run because it is skipped due to a 
    * failed prerequisite.
    *
-   * @param   unittest.TestSkipped skipped
+   * @param  unittest.TestSkipped $skipped
    */
   public function testSkipped(TestSkipped $skipped);
 
   /**
    * Called when a test is not run because it has been ignored by using
-   * the @ignore annotation.
+   * the `ignore` annotation.
    *
-   * @param   unittest.TestSkipped ignore
+   * @param  unittest.TestSkipped $ignore
    */
   public function testNotRun(TestSkipped $ignore);
 
   /**
    * Called when a test run starts.
    *
-   * @param   unittest.TestSuite suite
+   * @param  unittest.TestSuite $suite
    */
   public function testRunStarted(TestSuite $suite);
   
   /**
    * Called when a test run finishes.
    *
-   * @param   unittest.TestSuite suite
-   * @param   unittest.TestResult result
+   * @param  unittest.TestSuite $suite
+   * @param  unittest.TestResult $result
    */
   public function testRunFinished(TestSuite $suite, TestResult $result);
 }

--- a/src/main/php/unittest/TestNotRun.class.php
+++ b/src/main/php/unittest/TestNotRun.class.php
@@ -10,11 +10,11 @@ class TestNotRun extends TestSkipped {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  string $reason
    * @param  double $elapsed
    */
-  public function __construct(TestCase $test, $reason) {
+  public function __construct(Test $test, $reason) {
     parent::__construct($test, 0.0);
     $this->reason= $reason;
   }

--- a/src/main/php/unittest/TestOutcome.class.php
+++ b/src/main/php/unittest/TestOutcome.class.php
@@ -10,15 +10,15 @@ abstract class TestOutcome implements Value {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase test
-   * @param  double elapsed
+   * @param  unittest.Test $test
+   * @param  float $elapsed
    */
-  public function __construct(TestCase $test, $elapsed) {
+  public function __construct(Test $test, $elapsed) {
     $this->test= $test;
     $this->elapsed= $elapsed;
   }
 
-  /** @return unittest.TestCase */
+  /** @return unittest.TestO */
   public function test() { return $this->test; }
 
   /** @return double */

--- a/src/main/php/unittest/TestPrerequisitesFailed.class.php
+++ b/src/main/php/unittest/TestPrerequisitesFailed.class.php
@@ -10,11 +10,11 @@ class TestPrerequisitesFailed extends TestFailure {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  unittest.PrerequisitesNotMetError $reason
    * @param  double $elapsed
    */
-  public function __construct(TestCase $test, PrerequisitesFailedError $reason, $elapsed) {
+  public function __construct(Test $test, PrerequisitesFailedError $reason, $elapsed) {
     parent::__construct($test, $elapsed);
     $this->reason= $reason;
   }

--- a/src/main/php/unittest/TestPrerequisitesNotMet.class.php
+++ b/src/main/php/unittest/TestPrerequisitesNotMet.class.php
@@ -10,11 +10,11 @@ class TestPrerequisitesNotMet extends TestSkipped {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  unittest.PrerequisitesNotMetError $reason
    * @param  double $elapsed
    */
-  public function __construct(TestCase $test, PrerequisitesNotMetError $reason, $elapsed) {
+  public function __construct(Test $test, PrerequisitesNotMetError $reason, $elapsed) {
     parent::__construct($test, $elapsed);
     $this->reason= $reason;
   }

--- a/src/main/php/unittest/TestResult.class.php
+++ b/src/main/php/unittest/TestResult.class.php
@@ -46,63 +46,15 @@ class TestResult implements Value {
   /**
    * Returns the outcome of a specific test
    *
-   * @param   unittest.TestCase test
-   * @return  unittest.TestOutcome
+   * @param  unittest.Test $test
+   * @return unittest.TestOutcome
    */
-  public function outcomeOf(TestCase $test) {
+  public function outcomeOf($test) {
     $key= $test->hashCode();
     foreach ([$this->succeeded, $this->failed, $this->skipped] as $lookup) {
       if (isset($lookup[$key])) return $lookup[$key];
     }
     return null;
-  }
-
-  /**
-   * Set outcome for a given test
-   *
-   * @deprecated Use record() instead
-   * @param   unittest.TestCase test
-   * @param   unittest.TestOutcome outcome
-   * @return  unittest.TestOutcome the given outcome
-   */
-  public function set(TestCase $test, TestOutcome $outcome) {
-    return $this->record($outcome);
-  }
-  
-  /**
-   * Mark a test as succeeded
-   *
-   * @deprecated Use record() instead
-   * @param   unittest.TestCase test
-   * @param   float elapsed
-   */
-  public function setSucceeded($test, $elapsed) {
-    return $this->succeeded[$test->hashCode()]= new TestExpectationMet($test, $elapsed);
-  }
-  
-  /**
-   * Mark a test as failed
-   *
-   * @deprecated Use record() instead
-   * @param   unittest.TestCase test
-   * @param   var reason
-   * @param   float elapsed
-   */
-  public function setFailed($test, $reason, $elapsed) {
-    return $this->failed[$test->hashCode()]= new TestAssertionFailed($test, $reason, $elapsed);
-  }
-
-  /**
-   * Mark a test as been skipped
-   *
-   * @deprecated Use record() instead
-   * @param   unittest.TestCase test
-   * @param   var reason
-   * @param   float elapsed
-   * @return  unittest.TestSkipped s
-   */
-  public function setSkipped($test, $reason, $elapsed) {
-    return $this->skipped[$test->hashCode()]= new TestPrerequisitesNotMet($test, $reason, $elapsed);
   }
 
   /**

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -81,27 +81,6 @@ class TestRun {
   }
 
   /**
-   * Returns values
-   *
-   * @param  var $annotatable
-   * @return var[]
-   */
-  private function actionsFor($annotatable) {
-    $r= [];
-    if ($annotatable->hasAnnotation('action')) {
-      $action= $annotatable->getAnnotation('action');
-      if (is_array($action)) {
-        foreach ($action as $a) {
-          if ($a instanceof TestAction) $r[]= $a;
-        }
-      } else {
-        if ($action instanceof TestAction) $r[]= $action;
-      }
-    }
-    return $r;
-  }
-
-  /**
    * Invoke a block, wrap PHP5 and PHP7 native base exceptions in lang.Error
    *
    * @param  function(?): void $block
@@ -177,9 +156,6 @@ class TestRun {
       $values= [[]];
     }
 
-    // Check for @actions
-    $actions= array_merge($this->actionsFor(typeof($test->instance)), $this->actionsFor($test->method));
-
     $timer= new Timer();
     Errors::clear();
     foreach ($values as $args) {
@@ -190,7 +166,7 @@ class TestRun {
       try {
 
         // Before and after tests
-        foreach ($actions as $action) {
+        foreach ($test->actions as $action) {
           $this->invoke([$action, 'beforeTest'], $test);
           $tearDown= function($test, $error) use($tearDown, $action) {
             $propagated= $tearDown($test, $error);

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -205,20 +205,7 @@ class TestRun {
           };
         }
 
-        // Setup and teardown
-        $this->invoke([$test->asCase(), 'setUp'], null);
-        $tearDown= function($test, $error) use($tearDown) {
-          try {
-            $this->invoke([$test, 'tearDown'], null);
-            return $tearDown($test, $error);
-          } catch (Throwable $t) {
-            $error && $t->setCause($error);
-            return $tearDown($test, $t);
-          }
-        };
-
-        // Run test
-        $test->method->invoke($test->instance, is_array($args) ? $args : [$args]);
+        $test->run(is_array($args) ? $args : [$args]);
         $thrown= $tearDown($test->asCase(), null);
       } catch (TestAborted $aborted) {
         $tearDown($test->asCase(), $aborted);

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -135,13 +135,14 @@ class TestRun {
   /**
    * Run a test case.
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Target $target
    * @param  unittest.TestResult $result
    * @return void
    */
-  private function run($test) {
+  private function run($target) {
+    $test= $target->instance;
     $class= typeof($test);
-    $method= $class->getMethod($test->name);
+    $method= $class->getMethod($target->name);
     $this->notify('testStarted', [$test]);
     
     // Check for @ignore
@@ -310,8 +311,8 @@ class TestRun {
       return;
     }
 
-    foreach ($group->tests() as $test) {
-      $this->run($test);
+    foreach ($group->targets() as $target) {
+      $this->run($target);
     }
     $group->after();
   }

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -195,13 +195,13 @@ class TestRun {
       $group->before();
     } catch (PrerequisitesNotMetError $e) {
       $timer= new Timer();
-      foreach ($group->targets() as $test) {
+      foreach ($group->tests() as $test) {
         $this->record($e->type(), $e->outcome($test, $timer));
       }
       return;
     }
 
-    foreach ($group->targets() as $test) {
+    foreach ($group->tests() as $test) {
       $this->run($test);
     }
     $group->after();

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -192,7 +192,7 @@ class TestRun {
 
         // Before and after tests
         foreach ($actions as $action) {
-          $this->invoke([$action, 'beforeTest'], $test->asCase());
+          $this->invoke([$action, 'beforeTest'], $test);
           $tearDown= function($test, $error) use($tearDown, $action) {
             $propagated= $tearDown($test, $error);
             try {
@@ -206,15 +206,15 @@ class TestRun {
         }
 
         $test->run(is_array($args) ? $args : [$args]);
-        $thrown= $tearDown($test->asCase(), null);
+        $thrown= $tearDown($test, null);
       } catch (TestAborted $aborted) {
-        $tearDown($test->asCase(), $aborted);
+        $tearDown($test, $aborted);
         $this->record($aborted->type(), $aborted->outcome($t, $timer));
         continue;
       } catch (TargetInvocationException $invoke) {
-        $thrown= $tearDown($test->asCase(), $invoke->getCause());
+        $thrown= $tearDown($test, $invoke->getCause());
       } catch (Throwable $error) {
-        $thrown= $tearDown($test->asCase(), $error);
+        $thrown= $tearDown($test, $error);
       }
 
       // Check outcome

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -142,35 +142,34 @@ class TestRun {
   private function run($test) {
     $this->notify('testStarted', [$test]);
 
+    $annotations= $test->annotations();
+
     // Check for @ignore
-    if ($test->method->hasAnnotation('ignore')) {
-      $this->record('testNotRun', new TestNotRun($test, new IgnoredBecause($test->method->getAnnotation('ignore'))));
+    if (isset($annotations['ignore'])) {
+      $this->record('testNotRun', new TestNotRun($test, new IgnoredBecause($annotations['ignore'][0])));
       return;
     }
 
     // Check for @expect
     $expected= null;
-    if ($test->method->hasAnnotation('expect', 'class')) {
-      $message= $test->method->getAnnotation('expect', 'withMessage');
-      if ('' === $message || '/' === $message{0}) {
+    if (isset($annotations['expect'][0]['class'])) {
+      $message= $annotations['expect'][0]['withMessage'];
+      if ('' === $message || '/' === $message[0]) {
         $pattern= $message;
       } else {
         $pattern= '/'.preg_quote($message, '/').'/';
       }
-      $expected= [XPClass::forName($test->method->getAnnotation('expect', 'class')), $pattern];
-    } else if ($test->method->hasAnnotation('expect')) {
-      $expected= [XPClass::forName($test->method->getAnnotation('expect')), null];
+      $expected= [XPClass::forName($annotations['expect'][0]['class']), $pattern];
+    } else if (isset($annotations['expect'])) {
+      $expected= [XPClass::forName($annotations['expect'][0]), null];
     }
     
     // Check for @limit
-    $eta= 0;
-    if ($test->method->hasAnnotation('limit')) {
-      $eta= $test->method->getAnnotation('limit', 'time');
-    }
+    $eta= isset($annotations['limit']) ? $annotations['limit'][0]['time'] : 0;
 
     // Check for @values
-    if ($test->method->hasAnnotation('values')) {
-      $annotation= $test->method->getAnnotation('values');
+    if (isset($annotations['values'])) {
+      $annotation= $annotations['values'][0];
       $variation= true;
       $values= $this->valuesFor($test->instance, $annotation);
     } else {

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -40,7 +40,11 @@ class TestSuite implements \lang\Value {
    */
   public function addTestClass($class, $arguments= []) {
     $type= $class instanceof XPClass ? $class : XPClass::forName($class);
-    $this->sources[$type->literal()][]= new TestClass($type, $arguments);
+    if ($type->isSubclassOf(TestCase::class)) {
+      $this->sources[$type->literal()][]= new TestClass($type, $arguments);
+    } else {
+      $this->sources[$type->literal()][]= new TestTargets($type, $arguments);
+    }
     return $type;
   }
 

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -76,7 +76,7 @@ class TestSuite implements \lang\Value {
    * Returns test at a given position
    *
    * @param  int $pos
-   * @return unittest.TestCase or NULL if none was found
+   * @return unittest.Test or NULL if none was found
    */
   public function testAt($pos) {
     $num= 0;

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -1,22 +1,6 @@
 <?php namespace unittest;
 
 class TestTarget extends Test {
-  public $instance, $method, $actions;
-
-  public function __construct($instance, $method, $actions= []) {
-    $this->instance= $instance;
-    $this->method= $method;
-    $this->actions= $actions;
-  }
-
-  /** @return [:var] */
-  public function annotations() {
-    $return= [];
-    foreach ($this->method->getAnnotations() as $name => $value) {
-      $return[$name]= [$value];
-    }
-    return $return;
-  }
 
   /**
    * Runs this test target

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -32,21 +32,4 @@ class TestTarget implements Test {
   public function hashCode() {
     return md5(get_class($this->instance).':'.$this->method->getName());
   }
-
-  /** @deprecated */
-  private $case= null;
-
-  /** @deprecated */
-  public function asCase() {
-    if (null === $this->case) {
-      $name= $this->method->getName();
-      $instance= $this->instance;
-      $this->case= newinstance(TestCase::class, [$name], [
-        $name => function() use($instance, $name) {
-          return $instance->{$name}();
-        }
-      ]);
-    }
-    return $this->case;
-  }
 }

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -1,11 +1,12 @@
 <?php namespace unittest;
 
 class TestTarget extends Test {
-  public $instance, $method;
+  public $instance, $method, $actions;
 
-  public function __construct($instance, $method) {
+  public function __construct($instance, $method, $actions= []) {
     $this->instance= $instance;
     $this->method= $method;
+    $this->actions= $actions;
   }
 
   /** @return [:var] */

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -1,0 +1,52 @@
+<?php namespace unittest;
+
+class TestTarget implements Test {
+  public $instance, $method;
+
+  public function __construct($instance, $method) {
+    $this->instance= $instance;
+    $this->method= $method;
+  }
+
+  /**
+   * Runs this testcase
+   *
+   * @param  var[] $args
+   * @return void
+   * @throws lang.Throwable
+   */
+  public function run($args) {
+    $this->method->invoke($this->instance, $args);
+  }
+
+  /**
+   * Get this test target's name
+   *
+   * @param  bool $compound whether to use compound format
+   * @return string
+   */
+  public function getName($compound= false) {
+    return $compound ? nameof($this->instance).'::'.$this->method->getName() : $this->method->getName();
+  }
+
+  public function hashCode() {
+    return md5(get_class($this->instance).':'.$this->method->getName());
+  }
+
+  /** @deprecated */
+  private $case= null;
+
+  /** @deprecated */
+  public function asCase() {
+    if (null === $this->case) {
+      $name= $this->method->getName();
+      $instance= $this->instance;
+      $this->case= newinstance(TestCase::class, [$name], [
+        $name => function() use($instance, $name) {
+          return $instance->{$name}();
+        }
+      ]);
+    }
+    return $this->case;
+  }
+}

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -19,7 +19,7 @@ class TestTarget extends Test {
   }
 
   /**
-   * Runs this testcase
+   * Runs this test target
    *
    * @param  var[] $args
    * @return void

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -8,6 +8,15 @@ class TestTarget extends Test {
     $this->method= $method;
   }
 
+  /** @return [:var] */
+  public function annotations() {
+    $return= [];
+    foreach ($this->method->getAnnotations() as $name => $value) {
+      $return[$name]= [$value];
+    }
+    return $return;
+  }
+
   /**
    * Runs this testcase
    *
@@ -29,6 +38,7 @@ class TestTarget extends Test {
     return $compound ? nameof($this->instance).'::'.$this->method->getName() : $this->method->getName();
   }
 
+  /** @return string */
   public function hashCode() {
     return md5(get_class($this->instance).':'.$this->method->getName());
   }

--- a/src/main/php/unittest/TestTarget.class.php
+++ b/src/main/php/unittest/TestTarget.class.php
@@ -1,6 +1,6 @@
 <?php namespace unittest;
 
-class TestTarget implements Test {
+class TestTarget extends Test {
   public $instance, $method;
 
   public function __construct($instance, $method) {

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -44,11 +44,10 @@ class TestTargets extends TestGroup {
         $method->invoke($this->instance, []);
       } catch (TargetInvocationException $e) {
         $cause= $e->getCause();
-        if ($cause instanceof PrerequisitesNotMetError) {
-          throw $cause;
-        } else {
-          throw new PrerequisitesNotMetError('Exception in @before method '.$method->getName(), $cause);
-        }
+        throw $cause instanceof PrerequisitesNotMetError
+          ? $cause
+          : new PrerequisitesNotMetError('Exception in @before method '.$method->getName(), $cause);
+        ;
       }
     }
   }

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -1,0 +1,61 @@
+<?php namespace unittest;
+
+use lang\IllegalArgumentException;
+use lang\reflect\TargetInvocationException;
+
+class TestTargets extends TestGroup {
+  private $type;
+  private $instances= null;
+
+  static function __static() { }
+
+  /**
+   * Creates an instance from a type
+   *
+   * @param  lang.XPClass $type
+   */
+  public function __construct($type) {
+    if (!$type->reflect()->isInstantiable()) {
+      throw new IllegalArgumentException('Cannot instantiate '.$type->getName());
+    }
+    $this->type= $type;
+  }
+
+  private function instances() {
+    if (null === $this->instances) {
+      $this->instances= [];
+      $instance= $this->type->newInstance();
+      foreach ($this->type->getMethods() as $method) {
+        if ($method->hasAnnotation('test')) {
+          $name= $method->getName();
+          $this->instances[$name]= newinstance(TestCase::class, [$name], [
+            $name => function() use($instance, $method) {
+              try {
+                return $method->invoke($instance, []);
+              } catch (TargetInvocationException $e) {
+                throw $e->getCause();
+              }
+            }
+          ]);
+        }
+      }
+    }
+    return $this->instances;
+  }
+
+  /** @return lang.XPClass */
+  public function type() { return $this->type; }
+
+  /** @return int */
+  public function numTests() { return sizeof($this->instances()); }
+
+  /** @return iterable */
+  public function tests() { return array_values($this->instances()); }
+
+  /** @return iterable */
+  public function targets() {
+    foreach ($this->instances() as $name => $instance) {
+      yield new Target($name, $instance);
+    }
+  }
+}

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -32,36 +32,17 @@ class TestTargets extends TestGroup {
     }
   }
 
-  /**
-   * Runs actions before this group
-   *
-   * @return void
-   * @throws unittest.PrerequisitesNotMetError
-   */
-  public function before() {
-    foreach ($this->before as $method) {
-      try {
-        $method->invoke($this->instance, []);
-      } catch (TargetInvocationException $e) {
-        $cause= $e->getCause();
-        throw $cause instanceof PrerequisitesNotMetError
-          ? $cause
-          : new PrerequisitesNotMetError('Exception in @before method '.$method->getName(), $cause);
-        ;
-      }
+  /** @return iterable */
+  protected function beforeGroup() {
+    foreach ($this->before as $m) {
+      yield $m->getName() => $m->invoke($this->instance, []);
     }
   }
 
-  /**
-   * Runs actions after this group
-   *
-   * @return void
-   */
-  public function after() {
-    foreach ($this->after as $method) {
-      try {
-        $method->invoke($this->instance, []);
-      } catch (TargetInvocationException $ignored) { }
+  /** @return iterable */
+  protected function afterGroup() {
+    foreach ($this->after as $m) {
+      yield $m->getName() => $m->invoke($this->instance, []);
     }
   }
 

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -68,7 +68,7 @@ class TestTargets extends TestGroup {
   /** @return iterable */
   public function targets() {
     foreach ($this->tests as $method) {
-      yield new Test($this->instance, $method);
+      yield new TestTarget($this->instance, $method);
     }
   }
 }

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -62,19 +62,6 @@ class TestTargets extends TestGroup {
 
   /** @return iterable */
   public function tests() {
-    $instance= $this->instance;
-    foreach ($this->tests as $method) {
-      $name= $method->getName();
-      yield newinstance(TestCase::class, [$name], [
-        $name => function() use($instance, $name) {
-          return $instance->{$name}();
-        }
-      ]);
-    }
-  }
-
-  /** @return iterable */
-  public function targets() {
     foreach ($this->tests as $method) {
       yield new TestTarget($this->instance, $method, array_merge(
         $this->actions,

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -4,7 +4,7 @@ use lang\IllegalArgumentException;
 use lang\reflect\TargetInvocationException;
 
 class TestTargets extends TestGroup {
-  private $type;
+  private $type, $arguments;
   private $instances= null;
 
   static function __static() { }
@@ -13,18 +13,20 @@ class TestTargets extends TestGroup {
    * Creates an instance from a type
    *
    * @param  lang.XPClass $type
+   * @param  var[] $arguments
    */
-  public function __construct($type) {
+  public function __construct($type, $arguments= []) {
     if (!$type->reflect()->isInstantiable()) {
       throw new IllegalArgumentException('Cannot instantiate '.$type->getName());
     }
     $this->type= $type;
+    $this->arguments= $arguments;
   }
 
   private function instances() {
     if (null === $this->instances) {
       $this->instances= [];
-      $instance= $this->type->newInstance();
+      $instance= $this->type->newInstance(...$this->arguments);
       foreach ($this->type->getMethods() as $method) {
         if ($method->hasAnnotation('test')) {
           $name= $method->getName();

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -30,7 +30,7 @@ class TestTargets extends TestGroup {
       foreach ($this->type->getMethods() as $method) {
         if ($method->hasAnnotation('test')) {
           $name= $method->getName();
-          $this->instances[$name]= newinstance(TestCase::class, [$name], [
+          $this->instances[]= newinstance(TestCase::class, [$name], [
             $name => function() use($instance, $method) {
               try {
                 return $method->invoke($instance, []);
@@ -52,12 +52,15 @@ class TestTargets extends TestGroup {
   public function numTests() { return sizeof($this->instances()); }
 
   /** @return iterable */
-  public function tests() { return array_values($this->instances()); }
+  public function tests() { return $this->instances(); }
 
   /** @return iterable */
   public function targets() {
-    foreach ($this->instances() as $name => $instance) {
-      yield new Target($name, $instance);
+    $instance= $this->type->newInstance(...$this->arguments);
+    foreach ($this->type->getMethods() as $method) {
+      if ($method->hasAnnotation('test')) {
+        yield new Test($instance, $method);
+      }
     }
   }
 }

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -36,7 +36,7 @@ class TestTargets extends TestGroup {
     }
 
     if (empty($this->tests)) {
-      throw new NoSuchElementException('No tests found in '.$class->getName());
+      throw new NoSuchElementException('No tests found in '.$type->getName());
     }
   }
 

--- a/src/main/php/unittest/TestTargets.class.php
+++ b/src/main/php/unittest/TestTargets.class.php
@@ -23,7 +23,7 @@ class TestTargets extends TestGroup {
       throw new IllegalArgumentException('Cannot instantiate '.$type->getName());
     }
 
-    $this->instance= $type->newInstance(...$this->arguments);
+    $this->instance= $type->newInstance(...$arguments);
     $this->actions= iterator_to_array($this->actionsFor($type, TestAction::class));
     foreach ($type->getMethods() as $method) {
       if ($method->hasAnnotation('test')) {

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -7,7 +7,7 @@ use util\Objects;
  *
  * @see   xp://unittest.TestCase
  */
-class TestVariation extends Test {
+class TestVariation implements Test {
   private $base, $variation;
 
   /**

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -22,9 +22,6 @@ class TestVariation extends Test {
     $this->args= $args;
   }
 
-  /** @return [:var] */
-  public function annotations() { return $this->base->annotations(); }
-
   /** @return string */
   private function variation() {
     if (null === $this->variation) {

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -7,22 +7,22 @@ use util\Objects;
  *
  * @see   xp://unittest.TestCase
  */
-class TestVariation extends TestCase {
-  protected $base= null;
+class TestVariation extends Test {
+  private $base, $variation;
 
   /**
    * Constructor
    *
-   * @param   unittest.TestCase base
-   * @param   var[] args
+   * @param  unittest.Test $base
+   * @param  var[] $args
    */
   public function __construct($base, $args) {
-    $uniq= '';
-    foreach ((array)$args as $arg) {
-      $uniq.= ', '.Objects::stringOf($arg);
-    }
-    parent::__construct($base->getName().'('.substr($uniq, 2).')');
     $this->base= $base;
+    $v= '';
+    foreach ((array)$args as $arg) {
+      $v.= ', '.Objects::stringOf($arg);
+    }
+    $this->variation= substr($v, 2);
   }
 
   /**
@@ -32,7 +32,11 @@ class TestVariation extends TestCase {
    * @return  string
    */
   public function getName($compound= false) {
-    return $compound ? nameof($this->base).'::'.$this->name : $this->name;
+    return $this->base->getName($compound).'('.$this->variation.')';
+  }
+
+  public function hashCode() {
+    return md5($this->base->hashCode().$this->variation);
   }
 
   /**
@@ -41,6 +45,6 @@ class TestVariation extends TestCase {
    * @return  string
    */
   public function toString() {
-    return nameof($this).'<'.nameof($this->base).'::'.$this->name.'>';
+    return nameof($this).'<'.$this->base->getName($compound).'>';
   }
 }

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -25,6 +25,9 @@ class TestVariation extends Test {
     $this->variation= substr($v, 2);
   }
 
+  /** @return [:var] */
+  public function annotations() { return $this->base->annotations(); }
+
   /**
    * Get this test cases' name
    *
@@ -35,6 +38,7 @@ class TestVariation extends Test {
     return $this->base->getName($compound).'('.$this->variation.')';
   }
 
+  /** @return string */
   public function hashCode() {
     return md5($this->base->hashCode().$this->variation);
   }

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -8,7 +8,8 @@ use util\Objects;
  * @see   xp://unittest.TestCase
  */
 class TestVariation extends Test {
-  private $base, $variation;
+  private $base, $args;
+  private $variation= null;
 
   /**
    * Constructor
@@ -18,15 +19,34 @@ class TestVariation extends Test {
    */
   public function __construct($base, $args) {
     $this->base= $base;
-    $v= '';
-    foreach ((array)$args as $arg) {
-      $v.= ', '.Objects::stringOf($arg);
-    }
-    $this->variation= substr($v, 2);
+    $this->args= $args;
   }
 
   /** @return [:var] */
   public function annotations() { return $this->base->annotations(); }
+
+  /** @return string */
+  private function variation() {
+    if (null === $this->variation) {
+      $v= '';
+      foreach ($this->args as $arg) {
+        $v.= ', '.Objects::stringOf($arg);
+      }
+      $this->variation= substr($v, 2);
+    }
+    return $this->variation;
+  }
+
+  /**
+   * Runs this test target
+   *
+   * @param  var[] $args
+   * @return void
+   * @throws lang.Throwable
+   */
+  public function run($args) {
+    $this->base->run($this->args);
+  }
 
   /**
    * Get this test cases' name
@@ -35,11 +55,11 @@ class TestVariation extends Test {
    * @return  string
    */
   public function getName($compound= false) {
-    return $this->base->getName($compound).'('.$this->variation.')';
+    return $this->base->getName($compound).'('.$this->variation().')';
   }
 
   /** @return string */
   public function hashCode() {
-    return md5($this->base->hashCode().$this->variation);
+    return md5($this->base->hashCode().$this->variation());
   }
 }

--- a/src/main/php/unittest/TestVariation.class.php
+++ b/src/main/php/unittest/TestVariation.class.php
@@ -7,7 +7,7 @@ use util\Objects;
  *
  * @see   xp://unittest.TestCase
  */
-class TestVariation implements Test {
+class TestVariation extends Test {
   private $base, $variation;
 
   /**
@@ -37,14 +37,5 @@ class TestVariation implements Test {
 
   public function hashCode() {
     return md5($this->base->hashCode().$this->variation);
-  }
-
-  /**
-   * Creates a string representation of this testcase
-   *
-   * @return  string
-   */
-  public function toString() {
-    return nameof($this).'<'.$this->base->getName($compound).'>';
   }
 }

--- a/src/main/php/unittest/TestWarning.class.php
+++ b/src/main/php/unittest/TestWarning.class.php
@@ -10,11 +10,11 @@ class TestWarning extends TestFailure {
   /**
    * Constructor
    *
-   * @param  unittest.TestCase $test
+   * @param  unittest.Test $test
    * @param  string[] $warnings
    * @param  double $elapsed
    */
-  public function __construct(TestCase $test, array $warnings, $elapsed) {
+  public function __construct(Test $test, array $warnings, $elapsed) {
     parent::__construct($test, $elapsed);
     $this->reason= new Warnings($warnings);
   }

--- a/src/main/php/unittest/actions/ExtensionAvailable.class.php
+++ b/src/main/php/unittest/actions/ExtensionAvailable.class.php
@@ -2,7 +2,8 @@
 
 use lang\Runtime;
 use unittest\PrerequisitesNotMetError;
-use unittest\TestCase;
+use unittest\Test;
+use unittest\TestAction;
 
 /**
  * Only runs this testcase if a given PHP extension is available
@@ -10,7 +11,7 @@ use unittest\TestCase;
  * @test  xp://net.xp_framework.unittest.tests.ExtensionAvailableTest
  * @see   xp://lang.Runtime#extensionAvailable
  */
-class ExtensionAvailable implements \unittest\TestAction {
+class ExtensionAvailable implements TestAction {
   protected $extension= '';
 
   /**
@@ -35,10 +36,10 @@ class ExtensionAvailable implements \unittest\TestAction {
    * This method gets invoked before a test method is invoked, and before
    * the setUp() method is called.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    * @throws unittest.PrerequisitesNotMetError
    */
-  public function beforeTest(TestCase $t) { 
+  public function beforeTest(Test $t) { 
     if (!$this->verify()) {
       throw new PrerequisitesNotMetError('PHP Extension not available', null, [$this->extension]);
     }
@@ -48,9 +49,9 @@ class ExtensionAvailable implements \unittest\TestAction {
    * This method gets invoked after the test method is invoked and regard-
    * less of its outcome, after the tearDown() call has run.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function afterTest(TestCase $t) {
+  public function afterTest(Test $t) {
     // Empty
   }
 }

--- a/src/main/php/unittest/actions/IsPlatform.class.php
+++ b/src/main/php/unittest/actions/IsPlatform.class.php
@@ -1,7 +1,8 @@
 <?php namespace unittest\actions;
 
 use unittest\PrerequisitesNotMetError;
-use unittest\TestCase;
+use unittest\Test;
+use unittest\TestAction;
 
 /**
  * Only runs this testcase on a given platform
@@ -13,7 +14,7 @@ use unittest\TestCase;
  *
  * @test  xp://net.xp_framework.unittest.tests.IsPlatformTest
  */
-class IsPlatform implements \unittest\TestAction {
+class IsPlatform implements TestAction {
   protected $platform= '';
   protected static $os= '';
 
@@ -53,10 +54,10 @@ class IsPlatform implements \unittest\TestAction {
    * This method gets invoked before a test method is invoked, and before
    * the setUp() method is called.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    * @throws unittest.PrerequisitesNotMetError
    */
-  public function beforeTest(TestCase $t) { 
+  public function beforeTest(Test $t) { 
     if (!$this->verify()) {
       throw new PrerequisitesNotMetError('Test not intended for this platform ('.self::$os.')', null, [$this->platform]);
     }
@@ -66,9 +67,9 @@ class IsPlatform implements \unittest\TestAction {
    * This method gets invoked after the test method is invoked and regard-
    * less of its outcome, after the tearDown() call has run.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function afterTest(TestCase $t) {
+  public function afterTest(Test $t) {
     // Empty
   }
 }

--- a/src/main/php/unittest/actions/RuntimeVersion.class.php
+++ b/src/main/php/unittest/actions/RuntimeVersion.class.php
@@ -20,11 +20,11 @@ class RuntimeVersion implements TestAction {
    */
   public function __construct($pattern) {
     foreach (explode(',', $pattern) as $specifier) {
-      if ('*' === $specifier{strlen($specifier)- 1}) {
+      if ('*' === $specifier[strlen($specifier)- 1]) {
         $this->compare[]= function($compare) use($specifier) {
           return 0 === strncmp($compare, $specifier, strlen($specifier)- 1);
         };
-      } else if ('~' === $specifier{0}) {
+      } else if ('~' === $specifier[0]) {
         $c= sscanf($specifier, '~%d.%d.%d', $s, $m, $p);
         $lower= substr($specifier, 1);
         switch ($c) {
@@ -34,8 +34,8 @@ class RuntimeVersion implements TestAction {
         $this->compare[]= function($compare) use($lower, $upper) {
           return version_compare($compare, $lower, 'ge') && version_compare($compare, $upper, 'lt');
         };
-      } else if ('<' === $specifier{0}) {
-        if ('=' === $specifier{1}) {
+      } else if ('<' === $specifier[0]) {
+        if ('=' === $specifier[1]) {
           $op= 'le';
           $specifier= substr($specifier, 2);
         } else {
@@ -45,8 +45,8 @@ class RuntimeVersion implements TestAction {
         $this->compare[]= function($compare) use($specifier, $op) {
           return version_compare($compare, $specifier, $op);
         };
-      } else if ('>' === $specifier{0}) {
-        if ('=' === $specifier{1}) {
+      } else if ('>' === $specifier[0]) {
+        if ('=' === $specifier[1]) {
           $op= 'ge';
           $specifier= substr($specifier, 2);
         } else {
@@ -56,7 +56,7 @@ class RuntimeVersion implements TestAction {
         $this->compare[]= function($compare) use($specifier, $op) {
           return version_compare($compare, $specifier, $op);
         };
-      } else if ('!=' === $specifier{0}.$specifier{1}) {
+      } else if ('!=' === $specifier[0].$specifier[1]) {
         $this->compare[]= function($compare) use($specifier) {
           return $compare !== substr($specifier, 2);
         };

--- a/src/main/php/unittest/actions/RuntimeVersion.class.php
+++ b/src/main/php/unittest/actions/RuntimeVersion.class.php
@@ -1,7 +1,8 @@
 <?php namespace unittest\actions;
 
 use unittest\PrerequisitesNotMetError;
-use unittest\TestCase;
+use unittest\Test;
+use unittest\TestAction;
 
 /**
  * Only runs this testcase on a given runtime version, e.g. PHP 5.4.0
@@ -9,7 +10,7 @@ use unittest\TestCase;
  * @test xp://net.xp_framework.unittest.tests.RuntimeVersionTest
  * @see  http://getcomposer.org/doc/01-basic-usage.md#package-versions
  */
-class RuntimeVersion implements \unittest\TestAction {
+class RuntimeVersion implements TestAction {
   protected $compare= [];
 
   /**
@@ -85,10 +86,10 @@ class RuntimeVersion implements \unittest\TestAction {
    * This method gets invoked before a test method is invoked, and before
    * the setUp() method is called.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    * @throws unittest.PrerequisitesNotMetError
    */
-  public function beforeTest(TestCase $t) { 
+  public function beforeTest(Test $t) { 
     if (!$this->verify()) {
       $compare= '';
       foreach ($this->compare as $f) {
@@ -107,9 +108,9 @@ class RuntimeVersion implements \unittest\TestAction {
    * This method gets invoked after the test method is invoked and regard-
    * less of its outcome, after the tearDown() call has run.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function afterTest(TestCase $t) {
+  public function afterTest(Test $t) {
     // Empty
   }
 }

--- a/src/main/php/unittest/actions/VerifyThat.class.php
+++ b/src/main/php/unittest/actions/VerifyThat.class.php
@@ -4,8 +4,8 @@ use lang\MethodNotImplementedException;
 use lang\Throwable;
 use lang\XPClass;
 use unittest\PrerequisitesNotMetError;
+use unittest\Test;
 use unittest\TestAction;
-use unittest\TestCase;
 use unittest\TestClassAction;
 
 /**
@@ -53,12 +53,12 @@ class VerifyThat implements TestAction, TestClassAction {
    * This method gets invoked before a test method is invoked, and before
    * the setUp() method is called.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    * @throws unittest.PrerequisitesNotMetError
    */
-  public function beforeTest(TestCase $t) {
+  public function beforeTest(Test $t) {
     try {
-      $verified= $this->verify->bindTo($t, $t)->__invoke();
+      $verified= $this->verify->bindTo($t->instance, $t->instance)->__invoke();
     } catch (Throwable $e) {
       throw new PrerequisitesNotMetError('Verification raised '.$e->compoundMessage(), null, [$this->prerequisite]);
     }
@@ -72,9 +72,9 @@ class VerifyThat implements TestAction, TestClassAction {
    * This method gets invoked after the test method is invoked and regard-
    * less of its outcome, after the tearDown() call has run.
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function afterTest(TestCase $t) {
+  public function afterTest(Test $t) {
     // Empty
   }
 

--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -3,6 +3,7 @@
 use io\streams\ConsoleOutputStream;
 use io\streams\OutputStreamWriter;
 use unittest\ColorizingListener;
+use unittest\Test;
 use unittest\TestListener;
 
 /**
@@ -73,9 +74,9 @@ class DefaultListener implements TestListener, ColorizingListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.Test $test
    */
-  public function testStarted(\unittest\TestCase $case) {
+  public function testStarted(Test $test) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/QuietListener.class.php
+++ b/src/main/php/xp/unittest/QuietListener.class.php
@@ -1,6 +1,7 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
+use unittest\Test;
 
 /**
  * Quiet listener
@@ -21,9 +22,9 @@ class QuietListener implements \unittest\TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.Test $test
    */
-  public function testStarted(\unittest\TestCase $case) {
+  public function testStarted(Test $test) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/StopListener.class.php
+++ b/src/main/php/xp/unittest/StopListener.class.php
@@ -1,14 +1,14 @@
 <?php namespace xp\unittest;
 
-use unittest\TestCase;
-use unittest\TestSuite;
-use unittest\TestResult;
-use unittest\TestFailure;
-use unittest\TestError;
-use unittest\TestWarning;
-use unittest\TestSuccess;
-use unittest\TestSkipped;
 use unittest\StopTests;
+use unittest\Test;
+use unittest\TestError;
+use unittest\TestFailure;
+use unittest\TestResult;
+use unittest\TestSkipped;
+use unittest\TestSuccess;
+use unittest\TestSuite;
+use unittest\TestWarning;
 
 /**
  * Stop listener
@@ -34,9 +34,9 @@ class StopListener implements \unittest\TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.TestCase $case
+   * @param  unittest.Test $test
    */
-  public function testStarted(TestCase $case) {
+  public function testStarted(Test $test) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/VerboseListener.class.php
+++ b/src/main/php/xp/unittest/VerboseListener.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
-use unittest\TestCase;
+use unittest\Test;
 use unittest\TestListener;
 
 /**
@@ -25,9 +25,9 @@ class VerboseListener implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.Test $test
    */
-  public function testStarted(TestCase $case) {
+  public function testStarted(Test $test) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/XTermTitleListener.class.php
+++ b/src/main/php/xp/unittest/XTermTitleListener.class.php
@@ -1,9 +1,9 @@
 <?php namespace xp\unittest;
 
-use unittest\TestListener;
-use unittest\TestCase;
-use unittest\TestSuite;
 use io\streams\OutputStreamWriter;
+use unittest\Test;
+use unittest\TestListener;
+use unittest\TestSuite;
 
 /**
  * XTerm Title listener
@@ -28,27 +28,26 @@ class XTermTitleListener implements TestListener {
   /**
    * Write status of currently executing test case
    *
-   * @param   unittest.TestCase case
+   * @param   unittest.Test $test
    */
-  private function writeStatus(TestCase $case) {
+  private function writeStatus(Test $test) {
     $this->cur++;
 
     $perc= floor($this->cur / $this->sum * self::PROGRESS_WIDTH);
 
-    $this->out->writef("\033]2;Running: [%s%s] %s::%s()\007",
+    $this->out->writef("\033]2;Running: [%s%s] %s()\007",
       str_repeat('*', $perc), str_repeat('-', self::PROGRESS_WIDTH- $perc),
-      nameof($case),
-      $case->getName()
+      $test->getName(true)
     );
   }
 
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.Test $test
    */
-  public function testStarted(TestCase $case) {
-    $this->writeStatus($case);
+  public function testStarted(Test $test) {
+    $this->writeStatus($test);
   }
 
   /**

--- a/src/main/php/xp/unittest/XmlTestListener.class.php
+++ b/src/main/php/xp/unittest/XmlTestListener.class.php
@@ -1,10 +1,10 @@
 <?php namespace unittest;
 
 use io\streams\OutputStreamWriter;
-use xml\Tree;
-use util\collections\HashTable;
 use lang\XPClass;
 use util\Objects;
+use util\collections\HashTable;
+use xml\Tree;
 
 /**
  * Creates an XML file suitable for importing into continuous integration
@@ -74,9 +74,9 @@ class XmlTestListener implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.Test $test
    */
-  public function testStarted(TestCase $case) {
+  public function testStarted(Test $test) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/sources/ClassesSource.class.php
+++ b/src/main/php/xp/unittest/sources/ClassesSource.class.php
@@ -21,7 +21,12 @@ abstract class ClassesSource {
     $empty= true;
 
     foreach ($this->classes() as $class) {
-      if ($class->isSubclassOf(TestCase::class) && !Modifiers::isAbstract($class->getModifiers())) {
+      if (Modifiers::isAbstract($class->getModifiers())) {
+        continue;
+      } else if ($class->isSubclassOf(TestCase::class)) {
+        $suite->addTestClass($class, $arguments);
+        $empty= false;
+      } else if (0 === substr_compare($class->getName(), 'Test', -4)) {
         $suite->addTestClass($class, $arguments);
         $empty= false;
       }

--- a/src/test/php/unittest/tests/AssertTest.class.php
+++ b/src/test/php/unittest/tests/AssertTest.class.php
@@ -1,0 +1,89 @@
+<?php namespace unittest\tests;
+
+use unittest\Assert;
+use unittest\AssertionFailedError;
+
+class AssertTest {
+
+  /** @return iterable */
+  private function values() {
+    return [
+      [0], [1], [-1],
+      [''], ['Test'],
+      [true], [false], [null],
+      [[]], [[1, 2, 3]], [['key' => 'value']],
+      [function() { }],
+      [new Value('Test')],
+    ];
+  }
+
+  #[@test, @values('values')]
+  public function values_equal_themselves($value) {
+    Assert::equals($value, $value);
+  }
+
+  #[@test, @values('values')]
+  public function values_do_not_equal_this($value) {
+    Assert::notEquals($this, $value);
+  }
+
+  #[@test]
+  public function true_equals() {
+    Assert::true(true);
+  }
+
+  #[@test]
+  public function false_equals() {
+    Assert::false(false);
+  }
+
+  #[@test]
+  public function null_equals() {
+    Assert::null(null);
+  }
+
+  #[@test]
+  public function instanceof_self() {
+    Assert::instance(self::class, $this);
+  }
+
+  #[@test]
+  public function instanceof_subclass() {
+    Assert::instance(Value::class, newinstance(Value::class, [$this], []));
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function equals_raises_error_when_not_equal() {
+    Assert::equals(1, 2);
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function notEquals_raises_error_when_equal() {
+    Assert::notEquals(1, 1);
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function true_raises_error_when_not_true() {
+    Assert::true(false);
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function false_raises_error_when_not_false() {
+    Assert::false(true);
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function null_raises_error_when_not_null() {
+    Assert::null($this);
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function instanceof_raises_error_when_given_non_object() {
+    Assert::instance(self::class, null);
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function instanceof_raises_error_when_given_non_instance() {
+    Assert::instance(Value::class, $this);
+  }
+}

--- a/src/test/php/unittest/tests/BeforeAndAfterClassWithRunTest.class.php
+++ b/src/test/php/unittest/tests/BeforeAndAfterClassWithRunTest.class.php
@@ -10,7 +10,7 @@ class BeforeAndAfterClassWithRunTest extends BeforeAndAfterClassTest {
   /**
    * Runs a test and returns the outcome
    *
-   * @param   unittest.TestCase $test
+   * @param   unittest.Test $test
    * @return  unittest.TestOutcome
    */
   protected function runTest($test) {

--- a/src/test/php/unittest/tests/BeforeAndAfterClassWithRunTestTest.class.php
+++ b/src/test/php/unittest/tests/BeforeAndAfterClassWithRunTestTest.class.php
@@ -10,7 +10,7 @@ class BeforeAndAfterClassWithRunTestTest extends BeforeAndAfterClassTest {
   /**
    * Runs a test and returns the outcome
    *
-   * @param   unittest.TestCase $test
+   * @param   unittest.Test $test
    * @return  unittest.TestOutcome
    */
   protected function runTest($test) {

--- a/src/test/php/unittest/tests/ListenerTest.class.php
+++ b/src/test/php/unittest/tests/ListenerTest.class.php
@@ -5,6 +5,7 @@ use unittest\PrerequisitesNotMetError;
 use unittest\Test;
 use unittest\TestAssertionFailed;
 use unittest\TestCase;
+use unittest\TestClassInstance;
 use unittest\TestError;
 use unittest\TestExpectationMet;
 use unittest\TestFailure;
@@ -42,7 +43,7 @@ class ListenerTest extends TestCase implements TestListener {
    * @param   unittest.Test $test
    */
   public function testStarted(Test $test) {
-    $this->invocations[__FUNCTION__]= [$test->asCase()];
+    $this->invocations[__FUNCTION__]= [$test];
   }
 
   /**
@@ -157,7 +158,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals($case, $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestExpectationMet::class, $this->invocations['testSucceeded'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -171,7 +172,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals($case, $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestAssertionFailed::class, $this->invocations['testFailed'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -185,7 +186,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals($case, $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestError::class, $this->invocations['testError'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -199,7 +200,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals($case, $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestWarning::class, $this->invocations['testWarning'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -214,7 +215,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals($case, $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestPrerequisitesNotMet::class, $this->invocations['testSkipped'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -228,7 +229,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals($case, $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestNotRun::class, $this->invocations['testNotRun'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);

--- a/src/test/php/unittest/tests/ListenerTest.class.php
+++ b/src/test/php/unittest/tests/ListenerTest.class.php
@@ -5,7 +5,7 @@ use unittest\PrerequisitesNotMetError;
 use unittest\Test;
 use unittest\TestAssertionFailed;
 use unittest\TestCase;
-use unittest\TestClassInstance;
+use unittest\TestCaseInstance;
 use unittest\TestError;
 use unittest\TestExpectationMet;
 use unittest\TestFailure;
@@ -158,7 +158,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestExpectationMet::class, $this->invocations['testSucceeded'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -172,7 +172,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestAssertionFailed::class, $this->invocations['testFailed'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -186,7 +186,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestError::class, $this->invocations['testError'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -200,7 +200,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestWarning::class, $this->invocations['testWarning'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -215,7 +215,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestPrerequisitesNotMet::class, $this->invocations['testSkipped'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -229,7 +229,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestClassInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestNotRun::class, $this->invocations['testNotRun'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);

--- a/src/test/php/unittest/tests/ListenerTest.class.php
+++ b/src/test/php/unittest/tests/ListenerTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\IllegalArgumentException;
 use unittest\PrerequisitesNotMetError;
+use unittest\Test;
 use unittest\TestAssertionFailed;
 use unittest\TestCase;
 use unittest\TestError;
@@ -38,10 +39,10 @@ class ListenerTest extends TestCase implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param   unittest.Test $test
    */
-  public function testStarted(TestCase $case) {
-    $this->invocations[__FUNCTION__]= [$case];
+  public function testStarted(Test $test) {
+    $this->invocations[__FUNCTION__]= [$test->asCase()];
   }
 
   /**

--- a/src/test/php/unittest/tests/NotATestClass.class.php
+++ b/src/test/php/unittest/tests/NotATestClass.class.php
@@ -1,5 +1,5 @@
 <?php namespace unittest\tests;
 
-abstract class NotATestClass {
+class NotATestClass {
   
 }

--- a/src/test/php/unittest/tests/NotATestClass.class.php
+++ b/src/test/php/unittest/tests/NotATestClass.class.php
@@ -1,5 +1,5 @@
 <?php namespace unittest\tests;
 
-class NotATest {
+abstract class NotATestClass {
   
 }

--- a/src/test/php/unittest/tests/RecordActionInvocation.class.php
+++ b/src/test/php/unittest/tests/RecordActionInvocation.class.php
@@ -1,6 +1,6 @@
 <?php namespace unittest\tests;
 
-use unittest\TestCase;
+use unittest\Test;
 
 /**
  * This class is used in the TestActionTest 
@@ -20,20 +20,20 @@ class RecordActionInvocation implements \unittest\TestAction {
   /**
    * Before test: Update field
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function beforeTest(TestCase $t) {
-    $f= typeof($t)->getField($this->field);
-    $f->set($t, array_merge($f->get($t), ['before']));
+  public function beforeTest(Test $t) {
+    $f= typeof($t->instance)->getField($this->field);
+    $f->set($t->instance, array_merge($f->get($t->instance), ['before']));
   }
 
   /**
    * After test: Update field
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function afterTest(TestCase $t) {
-    $f= typeof($t)->getField($this->field);
-    $f->set($t, array_merge($f->get($t), ['after']));
+  public function afterTest(Test $t) {
+    $f= typeof($t->instance)->getField($this->field);
+    $f->set($t->instance, array_merge($f->get($t->instance), ['after']));
   }
 }

--- a/src/test/php/unittest/tests/RuntimeVersionTest.class.php
+++ b/src/test/php/unittest/tests/RuntimeVersionTest.class.php
@@ -1,11 +1,13 @@
 <?php namespace unittest\tests;
 
+use unittest\TestCase;
+use unittest\TestClassInstance;
 use unittest\actions\RuntimeVersion;
 
 /**
  * Test test action "Runtime Version"
  */
-class RuntimeVersionTest extends \unittest\TestCase {
+class RuntimeVersionTest extends TestCase {
 
   #[@test]
   public function can_create() {
@@ -124,6 +126,6 @@ class RuntimeVersionTest extends \unittest\TestCase {
 
   #[@test, @expect(class= 'unittest.PrerequisitesNotMetError', withMessage= '/Test not intended for this version/')]
   public function beforeTest_throws_exception() {
-    (new RuntimeVersion('1.0.0'))->beforeTest($this);
+    (new RuntimeVersion('1.0.0'))->beforeTest(new TestClassInstance($this));
   }
 }

--- a/src/test/php/unittest/tests/RuntimeVersionTest.class.php
+++ b/src/test/php/unittest/tests/RuntimeVersionTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace unittest\tests;
 
 use unittest\TestCase;
-use unittest\TestClassInstance;
+use unittest\TestCaseInstance;
 use unittest\actions\RuntimeVersion;
 
 /**
@@ -126,6 +126,6 @@ class RuntimeVersionTest extends TestCase {
 
   #[@test, @expect(class= 'unittest.PrerequisitesNotMetError', withMessage= '/Test not intended for this version/')]
   public function beforeTest_throws_exception() {
-    (new RuntimeVersion('1.0.0'))->beforeTest(new TestClassInstance($this));
+    (new RuntimeVersion('1.0.0'))->beforeTest(new TestCaseInstance($this));
   }
 }

--- a/src/test/php/unittest/tests/SkipThis.class.php
+++ b/src/test/php/unittest/tests/SkipThis.class.php
@@ -8,7 +8,7 @@ use unittest\TestAction;
 /**
  * This class is used in the TestActionTest 
  */
-class SkipThisTest implements TestAction {
+class SkipThis implements TestAction {
 
   /**
    * Before test: Update field

--- a/src/test/php/unittest/tests/SkipThisTest.class.php
+++ b/src/test/php/unittest/tests/SkipThisTest.class.php
@@ -1,29 +1,30 @@
 <?php namespace unittest\tests;
 
-use unittest\TestCase;
-use unittest\PrerequisitesNotMetError;
 use lang\IllegalStateException;
+use unittest\PrerequisitesNotMetError;
+use unittest\Test;
+use unittest\TestAction;
 
 /**
  * This class is used in the TestActionTest 
  */
-class SkipThisTest implements \unittest\TestAction {
+class SkipThisTest implements TestAction {
 
   /**
    * Before test: Update field
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function beforeTest(TestCase $t) {
+  public function beforeTest(Test $t) {
     throw new PrerequisitesNotMetError('Skip');
   }
 
   /**
    * After test: Update field
    *
-   * @param  unittest.TestCase $t
+   * @param  unittest.Test $t
    */
-  public function afterTest(TestCase $t) {
+  public function afterTest(Test $t) {
     throw new IllegalStateException('Should never be run!'); 
   }
 }

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -180,7 +180,7 @@ class SuiteTest extends TestCase {
 
   #[@test, @expect(IllegalArgumentException::class)]
   public function addingANonTestClass() {
-    $this->suite->addTestClass(\lang\XPClass::forName('unittest.tests.NotATest'));
+    $this->suite->addTestClass(\lang\XPClass::forName('lang.Value'));
   }    
 
   #[@test]

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -90,22 +90,22 @@ class SuiteTest extends TestCase {
 
   #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function addNonTest() {
-    $this->suite->addTest(new NotATest());
+    $this->suite->addTest(new NotATestClass());
   }
 
   #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function addNonTest7() {
-    $this->suite->addTest(new NotATest());
+    $this->suite->addTest(new NotATestClass());
   }
 
   #[@test, @expect(IllegalArgumentException::class), @action(new RuntimeVersion('<7.0.0-dev'))]
   public function runNonTest() {
-    $this->suite->runTest(new NotATest());
+    $this->suite->runTest(new NotATestClass());
   }
 
   #[@test, @expect(Error::class), @action(new RuntimeVersion('>=7.0.0-dev'))]
   public function runNonTest7() {
-    $this->suite->runTest(new NotATest());
+    $this->suite->runTest(new NotATestClass());
   }
 
   #[@test, @expect(MethodNotImplementedException::class)]

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -8,6 +8,7 @@ use lang\MethodNotImplementedException;
 use unittest\AssertionFailedError;
 use unittest\PrerequisitesNotMetError;
 use unittest\TestCase;
+use unittest\TestCaseInstance;
 use unittest\TestPrerequisitesNotMet;
 use unittest\TestResult;
 use unittest\TestSuite;
@@ -145,8 +146,8 @@ class SuiteTest extends TestCase {
     ]);
     $this->suite->addTestClass($class);
     $this->assertEquals(2, $this->suite->numTests());
-    $this->assertInstanceOf(TestCase::class, $this->suite->testAt(0));
-    $this->assertInstanceOf(TestCase::class, $this->suite->testAt(1));
+    $this->assertInstanceOf(TestCaseInstance::class, $this->suite->testAt(0));
+    $this->assertInstanceOf(TestCaseInstance::class, $this->suite->testAt(1));
   }
 
   #[@test]
@@ -199,14 +200,14 @@ class SuiteTest extends TestCase {
   #[@test]
   public function tests_after_adding_one() {
     $this->suite->addTest($this);
-    $this->assertEquals([$this], iterator_to_array($this->suite->tests()));
+    $this->assertEquals([new TestCaseInstance($this)], iterator_to_array($this->suite->tests()));
   }
 
   #[@test]
   public function tests_after_adding_two() {
     $this->suite->addTest($this);
     $this->suite->addTest($this);
-    $this->assertEquals([$this, $this], iterator_to_array($this->suite->tests()));
+    $this->assertEquals([new TestCaseInstance($this), new TestCaseInstance($this)], iterator_to_array($this->suite->tests()));
   }
 
   #[@test]

--- a/src/test/php/unittest/tests/TestActionTest.class.php
+++ b/src/test/php/unittest/tests/TestActionTest.class.php
@@ -4,6 +4,7 @@ use lang\ClassLoader;
 use lang\IllegalStateException;
 use lang\XPClass;
 use unittest\PrerequisitesNotMetError;
+use unittest\Test;
 use unittest\TestCase;
 use unittest\TestPrerequisitesNotMet;
 use unittest\TestSuite;
@@ -77,8 +78,8 @@ class TestActionTest extends TestCase {
   public function afterTest_is_invoked_for_succeeding_actions() {
     $actions= [];
     ClassLoader::defineClass('unittest.tests.AllocateMemory', $this->parent, ['unittest.TestAction'], [
-      'beforeTest' => function(TestCase $t) use(&$actions) { $actions[]= 'allocated'; },
-      'afterTest' => function(TestCase $t) use(&$actions) { $actions[]= 'freed'; }
+      'beforeTest' => function(Test $t) use(&$actions) { $actions[]= 'allocated'; },
+      'afterTest'  => function(Test $t) use(&$actions) { $actions[]= 'freed'; }
     ]);
     $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @action([new \unittest\tests\AllocateMemory(), new \unittest\tests\SkipThisTest()])] fixture' => function() {
@@ -111,13 +112,13 @@ class TestActionTest extends TestCase {
         $this->platform= $platform;
       }
 
-      public function beforeTest(\unittest\TestCase $t) {
+      public function beforeTest(\unittest\Test $t) {
         if (PHP_OS !== $this->platform) {
           throw new \unittest\PrerequisitesNotMetError("Skip", NULL, $this->platform);
         }
       }
 
-      public function afterTest(\unittest\TestCase $t) {
+      public function afterTest(\unittest\Test $t) {
         // NOOP
       }
     }');
@@ -134,8 +135,8 @@ class TestActionTest extends TestCase {
   #[@test]
   public function skip_test_via_skip() {
     ClassLoader::defineClass('unittest.tests.SkipTest', $this->parent, ['unittest.TestAction'], [
-      'beforeTest' => function(TestCase $t) { $t->skip('Not run'); },
-      'afterTest' => function(TestCase $t) { }
+      'beforeTest' => function(Test $t) { $t->instance->skip('Not run'); },
+      'afterTest'  => function(Test $t) { }
     ]);
     $test= newinstance(TestCase::class, ['fixture'], [
       '#[@test, @action([new \unittest\tests\SkipTest()])] fixture' => function() {
@@ -168,11 +169,11 @@ class TestActionTest extends TestCase {
   #[@test]
   public function afterTest_can_raise_AssertionFailedErrors() {
     ClassLoader::defineClass('unittest.tests.FailOnTearDown', $this->parent, ['unittest.TestAction'], '{
-      public function beforeTest(\unittest\TestCase $t) {
+      public function beforeTest(\unittest\Test $t) {
         // NOOP
       }
 
-      public function afterTest(\unittest\TestCase $t) {
+      public function afterTest(\unittest\Test $t) {
         throw new \unittest\AssertionFailedError("Skip");
       }
     }');
@@ -194,11 +195,11 @@ class TestActionTest extends TestCase {
         $this->message= $message;
       }
 
-      public function beforeTest(\unittest\TestCase $t) {
+      public function beforeTest(\unittest\Test $t) {
         // NOOP
       }
 
-      public function afterTest(\unittest\TestCase $t) {
+      public function afterTest(\unittest\Test $t) {
         throw new \unittest\AssertionFailedError($this->message);
       }
     }');

--- a/src/test/php/unittest/tests/TestActionTest.class.php
+++ b/src/test/php/unittest/tests/TestActionTest.class.php
@@ -1,12 +1,12 @@
 <?php namespace unittest\tests;
 
-use unittest\TestPrerequisitesNotMet;
 use lang\ClassLoader;
-use lang\XPClass;
 use lang\IllegalStateException;
-use unittest\TestSuite;
-use unittest\TestCase;
+use lang\XPClass;
 use unittest\PrerequisitesNotMetError;
+use unittest\TestCase;
+use unittest\TestPrerequisitesNotMet;
+use unittest\TestSuite;
 
 /**
  * Test test actions
@@ -96,7 +96,7 @@ class TestActionTest extends TestCase {
     $r= $this->suite->run();
     $result= [];
     foreach ($r->succeeded as $outcome) {
-      $result= array_merge($result, $outcome->test->run);
+      $result= array_merge($result, $outcome->test->instance->run);
     }
 
     $this->assertEquals(['before', 'one', 'after', 'before', 'two', 'after'], $result );

--- a/src/test/php/unittest/tests/TestActionTest.class.php
+++ b/src/test/php/unittest/tests/TestActionTest.class.php
@@ -66,7 +66,7 @@ class TestActionTest extends TestCase {
   #[@test]
   public function beforeTest_can_skip_test() {
     $test= newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @action(new \unittest\tests\SkipThisTest())] fixture' => function() {
+      '#[@test, @action(new \unittest\tests\SkipThis())] fixture' => function() {
         throw new IllegalStateException('This test should have been skipped');
       }
     ]);
@@ -82,7 +82,7 @@ class TestActionTest extends TestCase {
       'afterTest'  => function(Test $t) use(&$actions) { $actions[]= 'freed'; }
     ]);
     $test= newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @action([new \unittest\tests\AllocateMemory(), new \unittest\tests\SkipThisTest()])] fixture' => function() {
+      '#[@test, @action([new \unittest\tests\AllocateMemory(), new \unittest\tests\SkipThis()])] fixture' => function() {
         throw new IllegalStateException('This test should have been skipped');
       }
     ]);

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -1,16 +1,18 @@
 <?php namespace unittest\tests;
  
-use unittest\TestSuite;
-use unittest\TestExpectationMet;
-use unittest\TestAssertionFailed;
-use unittest\TestError;
-use unittest\TestPrerequisitesNotMet;
-use unittest\TestNotRun;
-use unittest\TestWarning;
-use unittest\TestVariation;
-use unittest\PrerequisitesNotMetError;
-use unittest\AssertionFailedError;
 use lang\Error;
+use unittest\AssertionFailedError;
+use unittest\PrerequisitesNotMetError;
+use unittest\Test;
+use unittest\TestAssertionFailed;
+use unittest\TestCase;
+use unittest\TestError;
+use unittest\TestExpectationMet;
+use unittest\TestNotRun;
+use unittest\TestPrerequisitesNotMet;
+use unittest\TestSuite;
+use unittest\TestVariation;
+use unittest\TestWarning;
 use util\Objects;
 
 /**
@@ -18,17 +20,18 @@ use util\Objects;
  *
  * @see      xp://unittest.TestOutcome
  */
-class TestOutcomeTest extends \unittest\TestCase {
+class TestOutcomeTest extends TestCase {
 
   /**
    * Creates fixtures
    *
-   * @return unittest.TestCase[]
+   * @return iterable
    */
   public function fixtures() {
+    $test= new Test($this, typeof($this)->getMethod($this->name));
     return [
-      [$this, ''],
-      [new TestVariation($this, ['v']), '("v")']
+      [$test, ''],
+      [new TestVariation($test, ['v']), '("v")']
     ];
   }
 

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -5,7 +5,7 @@ use unittest\AssertionFailedError;
 use unittest\PrerequisitesNotMetError;
 use unittest\TestAssertionFailed;
 use unittest\TestCase;
-use unittest\TestClassInstance;
+use unittest\TestCaseInstance;
 use unittest\TestError;
 use unittest\TestExpectationMet;
 use unittest\TestNotRun;
@@ -28,7 +28,7 @@ class TestOutcomeTest extends TestCase {
    * @return iterable
    */
   public function fixtures() {
-    $test= new TestClassInstance($this);
+    $test= new TestCaseInstance($this);
     return [
       [$test, ''],
       [new TestVariation($test, ['v']), '("v")']

--- a/src/test/php/unittest/tests/TestOutcomeTest.class.php
+++ b/src/test/php/unittest/tests/TestOutcomeTest.class.php
@@ -3,9 +3,9 @@
 use lang\Error;
 use unittest\AssertionFailedError;
 use unittest\PrerequisitesNotMetError;
-use unittest\Test;
 use unittest\TestAssertionFailed;
 use unittest\TestCase;
+use unittest\TestClassInstance;
 use unittest\TestError;
 use unittest\TestExpectationMet;
 use unittest\TestNotRun;
@@ -28,7 +28,7 @@ class TestOutcomeTest extends TestCase {
    * @return iterable
    */
   public function fixtures() {
-    $test= new Test($this, typeof($this)->getMethod($this->name));
+    $test= new TestClassInstance($this);
     return [
       [$test, ''],
       [new TestVariation($test, ['v']), '("v")']

--- a/src/test/php/unittest/tests/TestResultTest.class.php
+++ b/src/test/php/unittest/tests/TestResultTest.class.php
@@ -2,8 +2,8 @@
  
 use unittest\AssertionFailedError;
 use unittest\PrerequisitesNotMetError;
-use unittest\Test;
 use unittest\TestCase;
+use unittest\TestClassInstance;
 use unittest\TestError;
 use unittest\TestResult;
 use unittest\TestSkipped;
@@ -15,7 +15,7 @@ class TestResultTest extends TestCase {
 
   /** @return void */
   public function setUp() {
-    $this->test= new Test($this, typeof($this)->getMethod($this->name));
+    $this->test= new TestClassInstance($this);
   }
 
   #[@test]

--- a/src/test/php/unittest/tests/TestResultTest.class.php
+++ b/src/test/php/unittest/tests/TestResultTest.class.php
@@ -2,6 +2,7 @@
  
 use unittest\AssertionFailedError;
 use unittest\PrerequisitesNotMetError;
+use unittest\Test;
 use unittest\TestCase;
 use unittest\TestError;
 use unittest\TestResult;
@@ -10,6 +11,12 @@ use unittest\TestSuccess;
 use unittest\metrics\Metric;
 
 class TestResultTest extends TestCase {
+  private $test;
+
+  /** @return void */
+  public function setUp() {
+    $this->test= new Test($this, typeof($this)->getMethod($this->name));
+  }
 
   #[@test]
   public function can_create() {
@@ -18,34 +25,34 @@ class TestResultTest extends TestCase {
 
   #[@test]
   public function record_success() {
-    $outcome= new TestSuccess($this, 0.0);
+    $outcome= new TestSuccess($this->test, 0.0);
     $this->assertEquals($outcome, (new TestResult())->record($outcome));
   }
 
   #[@test]
   public function record_skipped() {
-    $outcome= new TestSkipped($this, 0.0);
+    $outcome= new TestSkipped($this->test, 0.0);
     $this->assertEquals($outcome, (new TestResult())->record($outcome));
   }
 
   #[@test]
   public function record_failure() {
-    $outcome= new TestError($this, new AssertionFailedError('Fail!'), 0.0);
+    $outcome= new TestError($this->test, new AssertionFailedError('Fail!'), 0.0);
     $this->assertEquals($outcome, (new TestResult())->record($outcome));
   }
 
   #[@test]
   public function outcome_of_recorded_test() {
-    $outcome= new TestSuccess($this, 0.0);
+    $outcome= new TestSuccess($this->test, 0.0);
     $t= new TestResult();
     $t->record($outcome);
-    $this->assertEquals($outcome, $t->outcomeOf($this));
+    $this->assertEquals($outcome, $t->outcomeOf($this->test));
   }
 
   #[@test]
   public function outcome_of_non_existant_test() {
     $t= new TestResult();
-    $this->assertNull($t->outcomeOf($this));
+    $this->assertNull($t->outcomeOf($this->test));
   }
 
   #[@test]
@@ -60,7 +67,7 @@ class TestResultTest extends TestCase {
   #[@test]
   public function one_succeeded_test() {
     $t= new TestResult();
-    $t->record(new TestSuccess($this, 0.0));
+    $t->record(new TestSuccess($this->test, 0.0));
     $this->assertEquals(
       [1, 0, 0, 1, 1],
       [$t->successCount(), $t->skipCount(), $t->failureCount(), $t->runCount(), $t->count()]
@@ -70,9 +77,9 @@ class TestResultTest extends TestCase {
   #[@test]
   public function succeed_skipped_and_failed_tests() {
     $t= new TestResult();
-    $t->record(new TestSuccess($this, 0.0));
-    $t->record(new TestSkipped($this, 0.0));
-    $t->record(new TestError($this, new AssertionFailedError('Fail!'), 0.0));
+    $t->record(new TestSuccess($this->test, 0.0));
+    $t->record(new TestSkipped($this->test, 0.0));
+    $t->record(new TestError($this->test, new AssertionFailedError('Fail!'), 0.0));
     $this->assertEquals(
       [1, 1, 1, 2, 3],
       [$t->successCount(), $t->skipCount(), $t->failureCount(), $t->runCount(), $t->count()]
@@ -82,18 +89,18 @@ class TestResultTest extends TestCase {
   #[@test]
   public function elapsed() {
     $t= new TestResult();
-    $t->record(new TestSuccess($this, 1.0));
-    $t->record(new TestSkipped($this, 0.1));
-    $t->record(new TestError($this, new AssertionFailedError('Fail!'), 0.5));
+    $t->record(new TestSuccess($this->test, 1.0));
+    $t->record(new TestSkipped($this->test, 0.1));
+    $t->record(new TestError($this->test, new AssertionFailedError('Fail!'), 0.5));
     $this->assertEquals(1.6, $t->elapsed());
   }
 
   #[@test]
   public function string_representation() {
     $t= new TestResult();
-    $t->record(new TestSuccess($this, 0.0));
-    $t->record(new TestSkipped($this, 0.0));
-    $t->record(new TestError($this, new AssertionFailedError('Fail!'), 0.0));
+    $t->record(new TestSuccess($this->test, 0.0));
+    $t->record(new TestSkipped($this->test, 0.0));
+    $t->record(new TestError($this->test, new AssertionFailedError('Fail!'), 0.0));
     $this->assertNotEquals('', $t->toString());
   }
 
@@ -126,30 +133,5 @@ class TestResultTest extends TestCase {
       'format'    => function() { return 'Test'; }
     ]);
     $this->assertEquals($metric, (new TestResult())->metric('Test', $metric)->metrics()['Test']);
-  }
-
-  /** @deprecated */
-  #[@test]
-  public function set() {
-    $outcome= new TestSuccess($this, 0.0);
-    $this->assertEquals($outcome, (new TestResult())->set($this, $outcome));
-  }
-
-  /** @deprecated */
-  #[@test]
-  public function setSucceeded() {
-    (new TestResult())->setSucceeded($this, 0.0);
-  }
-
-  /** @deprecated */
-  #[@test]
-  public function setSkipped() {
-    (new TestResult())->setSkipped($this, new PrerequisitesNotMetError('Ignored'), 0.0);
-  }
-
-  /** @deprecated */
-  #[@test]
-  public function setFailed() {
-    (new TestResult())->setFailed($this, new AssertionFailedError('Failed'), 0.0);
   }
 }

--- a/src/test/php/unittest/tests/TestResultTest.class.php
+++ b/src/test/php/unittest/tests/TestResultTest.class.php
@@ -3,7 +3,7 @@
 use unittest\AssertionFailedError;
 use unittest\PrerequisitesNotMetError;
 use unittest\TestCase;
-use unittest\TestClassInstance;
+use unittest\TestCaseInstance;
 use unittest\TestError;
 use unittest\TestResult;
 use unittest\TestSkipped;
@@ -15,7 +15,7 @@ class TestResultTest extends TestCase {
 
   /** @return void */
   public function setUp() {
-    $this->test= new TestClassInstance($this);
+    $this->test= new TestCaseInstance($this);
   }
 
   #[@test]

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace unittest\tests;
 
-use unittest\TestCase;
-use xp\unittest\Runner;
 use io\streams\MemoryInputStream;
 use io\streams\MemoryOutputStream;
 use lang\ClassLoader;
+use unittest\TestCase;
+use xp\unittest\Runner;
 
 /**
  * TestCase
@@ -112,7 +112,7 @@ class UnittestRunnerTest extends TestCase {
   public function runNonTest() {
     $return= $this->runner->run(['lang.Value']);
     $this->assertEquals(2, $return);
-    $this->assertOnStream($this->err, '*** Error: Given argument is not a TestCase class (lang.XPClass<lang.Value>)');
+    $this->assertOnStream($this->err, '*** Error: Cannot instantiate lang.Value');
     $this->assertEquals('', $this->out->getBytes());
   }
 


### PR DESCRIPTION
Implements feature suggested in #36, and can now run both baseless tests as well as TestCase instances. 

### Baseless tests

* Class names must end with *Test* for easy discoverability
* Only a single instance is created and used for all test methods
* No more setUp() and tearDown(), `@beforeClass` /  `@afterClass` - instead, just `@before` and `@after` - both of which will be invoked *once* (and not for every test!)
* No base class, instead, `unittest.Assert` DSL

Example:

```php
use unittest\Assert;
use com\example\Plus;

class PlusTest {
  private $op;

  #[@before]
  public function op() {
    $this->op= new Plus();
  }

  #[@test]
  public function plus() {
    Assert::equals(2, $this->op->evaluate(1, 1));
  }
}
```

### Assert DSL

Intentionally kept really basic. If more elaborate matchers are necessary, use a library!

```php
public abstract class unittest.Assert {
  public static void equals(var $expected, var $actual, string $error)
  public static void notEquals(var $expected, var $actual, string $error)
  public static void true(var $actual, string $error)
  public static void false(var $actual, string $error)
  public static void null(var $actual, string $error)
  public static void instance(string|lang.Type $type, var $actual, string $error)
}
```

*The `instance` method was renamed slightly from its original `assertInstanceOf` to keep PHP 5.6 compatibility, which doesn't allow using the keyword `instanceof` as a method name.*

### Performance

Before:

```bash
$ xp test src/test/php/
# ...
♥: 446/455 run (9 skipped), 446 succeeded, 0 failed
Memory used: 5706.39 kB (7845.37 kB peak)
Time taken: 0.146 seconds
```

After:

```bash
$ xp test src/test/php/
# ...
♥: 445/454 run (9 skipped), 445 succeeded, 0 failed
Memory used: 6945.05 kB (7907.77 kB peak)
Time taken: 0.150 seconds
```

### Caution

⚠️ **While writing and running tests remains compatible this change breaks backwards compatibility when *using* the test API!**