### PR TITLE
Backwards compatible Listener API

### DIFF
--- a/src/main/php/unittest/Listener.class.php
+++ b/src/main/php/unittest/Listener.class.php
@@ -1,0 +1,77 @@
+<?php namespace unittest;
+
+/**
+ * To intercept certain events during a test run, add a listener to
+ * the test suite before calling its run() or runTest() methods.
+ *
+ * @test  xp://net.xp_framework.unittest.tests.ListenerTest
+ * @see   xp://unittest.TestSuite#addListener
+ */
+interface Listener {
+
+  /**
+   * Called when a test case starts.
+   *
+   * @param  unittest.TestStart $start
+   */
+  public function testStarted(TestStart $start);
+
+  /**
+   * Called when a test fails.
+   *
+   * @param  unittest.TestFailure $failure
+   */
+  public function testFailed(TestFailure $failure);
+
+  /**
+   * Called when a test errors.
+   *
+   * @param  unittest.TestFailure $error
+   */
+  public function testError(TestError $error);
+
+  /**
+   * Called when a test raises warnings.
+   *
+   * @param  unittest.TestWarning $warning
+   */
+  public function testWarning(TestWarning $warning);
+  
+  /**
+   * Called when a test finished successfully.
+   *
+   * @param  unittest.TestSuccess $success
+   */
+  public function testSucceeded(TestSuccess $success);
+
+  /**
+   * Called when a test is not run because it is skipped due to a 
+   * failed prerequisite.
+   *
+   * @param  unittest.TestSkipped $skipped
+   */
+  public function testSkipped(TestSkipped $skipped);
+
+  /**
+   * Called when a test is not run because it has been ignored by using
+   * the `ignore` annotation.
+   *
+   * @param  unittest.TestSkipped $ignore
+   */
+  public function testNotRun(TestSkipped $ignore);
+
+  /**
+   * Called when a test run starts.
+   *
+   * @param  unittest.TestSuite $suite
+   */
+  public function testRunStarted(TestSuite $suite);
+  
+  /**
+   * Called when a test run finishes.
+   *
+   * @param  unittest.TestSuite $suite
+   * @param  unittest.TestResult $result
+   */
+  public function testRunFinished(TestSuite $suite, TestResult $result);
+}

--- a/src/main/php/unittest/ListenerAdapter.class.php
+++ b/src/main/php/unittest/ListenerAdapter.class.php
@@ -1,0 +1,104 @@
+<?php namespace unittest;
+
+class ListenerAdapter implements Listener {
+  private $listener;
+
+  /** Creates a new adapter */
+  public function __construct(TestListener $listener) {
+    $this->listener= $listener;
+  }
+
+  /**
+   * Called when a test case starts.
+   *
+   * @param  unittest.TestStart $start
+   */
+  public function testStarted(TestStart $start) {
+    $test= $start->test();
+    if ($test instanceof TestCaseInstance) {
+      $this->listener->testStarted($test->instance);
+    } else {
+      $name= $test->getName();
+      return newinstance(TestCase::class, [$name], [
+        $name => function() use($test) {
+          $test->method->invoke($test->instance, []);
+        }
+      ]);
+    }
+  }
+
+  /**
+   * Called when a test fails.
+   *
+   * @param  unittest.TestFailure $failure
+   */
+  public function testFailed(TestFailure $failure) {
+    $this->listener->testFailed($failure);
+  }
+
+  /**
+   * Called when a test errors.
+   *
+   * @param  unittest.TestFailure $error
+   */
+  public function testError(TestError $error) {
+    $this->listener->testError($error);
+  }
+
+  /**
+   * Called when a test raises warnings.
+   *
+   * @param  unittest.TestWarning $warning
+   */
+  public function testWarning(TestWarning $warning) {
+    $this->listener->testWarning($warning);
+  }
+  
+  /**
+   * Called when a test finished successfully.
+   *
+   * @param  unittest.TestSuccess $success
+   */
+  public function testSucceeded(TestSuccess $success) {
+    $this->listener->testSucceeded($success);
+  }
+
+  /**
+   * Called when a test is not run because it is skipped due to a 
+   * failed prerequisite.
+   *
+   * @param  unittest.TestSkipped $skipped
+   */
+  public function testSkipped(TestSkipped $skipped) {
+    $this->listener->testSkipped($skipped);
+  }
+
+  /**
+   * Called when a test is not run because it has been ignored by using
+   * the `ignore` annotation.
+   *
+   * @param  unittest.TestSkipped $ignore
+   */
+  public function testNotRun(TestSkipped $ignore) {
+    $this->listener->testNotRun($ignore);
+  }
+
+  /**
+   * Called when a test run starts.
+   *
+   * @param  unittest.TestSuite $suite
+   */
+  public function testRunStarted(TestSuite $suite) {
+    $this->listener->testRunStarted($suite);
+  }
+  
+  /**
+   * Called when a test run finishes.
+   *
+   * @param  unittest.TestSuite $suite
+   * @param  unittest.TestResult $result
+   */
+  public function testRunFinished(TestSuite $suite, TestResult $result) {
+    $this->listener->testRunFinished($suite, $result);
+  }
+}

--- a/src/main/php/unittest/TestListener.class.php
+++ b/src/main/php/unittest/TestListener.class.php
@@ -4,6 +4,7 @@
  * To intercept certain events during a test run, add a listener to
  * the test suite before calling its run() or runTest() methods.
  *
+ * @deprecated Use Listener instead!
  * @test  xp://net.xp_framework.unittest.tests.ListenerTest
  * @see   xp://unittest.TestSuite#addListener
  */
@@ -12,9 +13,9 @@ interface TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestCase $test
    */
-  public function testStarted(Test $test);
+  public function testStarted(TestCase $test);
 
   /**
    * Called when a test fails.

--- a/src/main/php/unittest/TestRun.class.php
+++ b/src/main/php/unittest/TestRun.class.php
@@ -77,7 +77,7 @@ class TestRun {
    * @return void
    */
   private function run($test) {
-    $this->notify('testStarted', [$test]);
+    $this->notify('testStarted', [new TestStart($test)]);
 
     // Check for @ignore
     if ($reason= $test->ignored()) {

--- a/src/main/php/unittest/TestStart.class.php
+++ b/src/main/php/unittest/TestStart.class.php
@@ -1,0 +1,41 @@
+<?php namespace unittest;
+
+use lang\Value;
+use util\Objects;
+
+/** Test start */
+class TestStart implements Value {
+  private $test;
+
+  /**
+   * Constructor
+   *
+   * @param  unittest.Test $test
+   */
+  public function __construct(Test $test) {
+    $this->test= $test;
+  }
+
+  /** @return unittest.TestO */
+  public function test() { return $this->test; }
+
+  /** @return string */
+  public function toString() {
+    return sprintf('%s(test= %s)', nameof($this), $this->test->getName(true));
+  }
+
+  /** @return string */
+  public function hashCode() {
+    return '+'.$this->test->hashCode();
+  }
+
+  /**
+   * Compares this test outcome to a given value
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->test, $value->test) : 1;
+  }
+}

--- a/src/main/php/unittest/TestSuite.class.php
+++ b/src/main/php/unittest/TestSuite.class.php
@@ -108,21 +108,25 @@ class TestSuite implements \lang\Value {
   /**
    * Adds a listener
    *
-   * @param  unittest.TestListener $l
-   * @return unittest.TestListener the added listener
+   * @param  unittest.Listener $l
+   * @return unittest.Listener the added listener
    */
-  public function addListener(TestListener $l) {
-    $this->listeners[]= $l;
+  public function addListener($l) {
+    if ($l instanceof Listener) {
+      $this->listeners[]= $l;
+    } else {
+      $this->listeners[]= new ListenerAdapter($l);  // Deprecated usage
+    }
     return $l;
   }
 
   /**
    * Removes a listener
    *
-   * @param  unittest.TestListener $l
+   * @param  unittest.Listener $l
    * @return bool TRUE if the listener was removed, FALSE if not.
    */
-  public function removeListener(TestListener $l) {
+  public function removeListener(Listener $l) {
     for ($i= 0, $s= sizeof($this->listeners); $i < $s; $i++) {
       if ($this->listeners[$i] !== $l) continue;
 

--- a/src/main/php/xp/unittest/DefaultListener.class.php
+++ b/src/main/php/xp/unittest/DefaultListener.class.php
@@ -3,15 +3,15 @@
 use io\streams\ConsoleOutputStream;
 use io\streams\OutputStreamWriter;
 use unittest\ColorizingListener;
-use unittest\Test;
-use unittest\TestListener;
+use unittest\Listener;
+use unittest\TestStart;
 
 /**
  * Default listener
  * ----------------
  * Only shows details for failed tests. This listener has no options.
  */
-class DefaultListener implements TestListener, ColorizingListener {
+class DefaultListener implements Listener, ColorizingListener {
   const OUTPUT_WIDTH= 72;
 
   public $out= null;
@@ -74,9 +74,9 @@ class DefaultListener implements TestListener, ColorizingListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
+  public function testStarted(TestStart $start) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/QuietListener.class.php
+++ b/src/main/php/xp/unittest/QuietListener.class.php
@@ -1,14 +1,15 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
-use unittest\Test;
+use unittest\Listener;
+use unittest\TestStart;
 
 /**
  * Quiet listener
  * --------------
  * No output at all. This listener has no options.
  */
-class QuietListener implements \unittest\TestListener {
+class QuietListener implements Listener {
 
   /**
    * Constructor
@@ -22,9 +23,9 @@ class QuietListener implements \unittest\TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
+  public function testStarted(TestStart $start) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/StopListener.class.php
+++ b/src/main/php/xp/unittest/StopListener.class.php
@@ -1,11 +1,12 @@
 <?php namespace xp\unittest;
 
+use unittest\Listener;
 use unittest\StopTests;
-use unittest\Test;
 use unittest\TestError;
 use unittest\TestFailure;
 use unittest\TestResult;
 use unittest\TestSkipped;
+use unittest\TestStart;
 use unittest\TestSuccess;
 use unittest\TestSuite;
 use unittest\TestWarning;
@@ -15,7 +16,7 @@ use unittest\TestWarning;
  * -------------
  * Checks for given events and stops the run
  */
-class StopListener implements \unittest\TestListener {
+class StopListener implements Listener {
   const FAIL   = 0x0001;
   const SKIP   = 0x0002;
   const IGNORE = 0x0004;
@@ -34,9 +35,9 @@ class StopListener implements \unittest\TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
+  public function testStarted(TestStart $start) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/TestListeners.class.php
+++ b/src/main/php/xp/unittest/TestListeners.class.php
@@ -1,9 +1,12 @@
 <?php namespace xp\unittest;
 
+use io\streams\OutputStreamWriter;
+use lang\Enum;
+
 /**
  * Listeners enumeration
  */
-abstract class TestListeners extends \lang\Enum {
+abstract class TestListeners extends Enum {
   public static $DEFAULT, $VERBOSE, $QUIET;
   
   static function __static() {
@@ -40,7 +43,7 @@ abstract class TestListeners extends \lang\Enum {
    * @param   io.streams.OutputStreamWriter out
    * @return  unittest.TestListener
    */
-  public function newInstance(\io\streams\OutputStreamWriter $out) {
+  public function newInstance(OutputStreamWriter $out) {
     return $this->getImplementation()->newInstance($out);
   }
 }

--- a/src/main/php/xp/unittest/VerboseListener.class.php
+++ b/src/main/php/xp/unittest/VerboseListener.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\OutputStreamWriter;
 use unittest\Listener;
-use unittest\Test;
+use unittest\TestStart;
 
 /**
  * Verbose listener

--- a/src/main/php/xp/unittest/VerboseListener.class.php
+++ b/src/main/php/xp/unittest/VerboseListener.class.php
@@ -1,8 +1,8 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
+use unittest\Listener;
 use unittest\Test;
-use unittest\TestListener;
 
 /**
  * Verbose listener
@@ -10,7 +10,7 @@ use unittest\TestListener;
  * Shows details for all tests (succeeded, failed and skipped/ignored).
  * This listener has no options.
  */
-class VerboseListener implements TestListener {
+class VerboseListener implements Listener {
   public $out= null;
   
   /**
@@ -25,9 +25,9 @@ class VerboseListener implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
+  public function testStarted(TestStart $start) {
     // NOOP
   }
 

--- a/src/main/php/xp/unittest/XTermTitleListener.class.php
+++ b/src/main/php/xp/unittest/XTermTitleListener.class.php
@@ -1,8 +1,8 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
-use unittest\Test;
-use unittest\TestListener;
+use unittest\Listener;
+use unittest\TestStart;
 use unittest\TestSuite;
 
 /**
@@ -11,7 +11,7 @@ use unittest\TestSuite;
  * Updates the window title bar of an xterm or xterm-compatible shell
  * window. This listener has no options.
  */
-class XTermTitleListener implements TestListener {
+class XTermTitleListener implements Listener {
   const PROGRESS_WIDTH= 20;
   private $out= null;
   private $cur, $sum;
@@ -44,9 +44,9 @@ class XTermTitleListener implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
+  public function testStarted(TestStart $start) {
     $this->writeStatus($test);
   }
 

--- a/src/main/php/xp/unittest/XmlTestListener.class.php
+++ b/src/main/php/xp/unittest/XmlTestListener.class.php
@@ -2,6 +2,7 @@
 
 use io\streams\OutputStreamWriter;
 use lang\XPClass;
+use unittest\Listener;
 use util\Objects;
 use util\collections\HashTable;
 use xml\Tree;
@@ -12,7 +13,7 @@ use xml\Tree;
  *
  * @test  xp://net.xp_framework.unittests.tests.XmlListenerTest
  */
-class XmlTestListener implements TestListener {
+class XmlTestListener implements Listener {
   public $out= null;
   protected $tree= null;
   protected $classes= [];
@@ -74,9 +75,9 @@ class XmlTestListener implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param  unittest.Test $test
+   * @param  unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
+  public function testStarted(TestStart $start) {
     // NOOP
   }
 

--- a/src/test/php/unittest/tests/ListenerTest.class.php
+++ b/src/test/php/unittest/tests/ListenerTest.class.php
@@ -1,29 +1,23 @@
 <?php namespace unittest\tests;
 
 use lang\IllegalArgumentException;
+use unittest\Listener;
 use unittest\PrerequisitesNotMetError;
-use unittest\Test;
 use unittest\TestAssertionFailed;
 use unittest\TestCase;
-use unittest\TestCaseInstance;
 use unittest\TestError;
 use unittest\TestExpectationMet;
 use unittest\TestFailure;
-use unittest\TestListener;
 use unittest\TestNotRun;
 use unittest\TestPrerequisitesNotMet;
 use unittest\TestResult;
 use unittest\TestSkipped;
+use unittest\TestStart;
 use unittest\TestSuccess;
 use unittest\TestSuite;
 use unittest\TestWarning;
 
-/**
- * TestCase
- *
- * @see   xp://unittest.TestListener
- */
-class ListenerTest extends TestCase implements TestListener {
+class ListenerTest extends TestCase implements Listener {
   private $suite, $invocations;
     
   /** @return void */
@@ -40,10 +34,10 @@ class ListenerTest extends TestCase implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.Test $test
+   * @param   unittest.TestStart $start
    */
-  public function testStarted(Test $test) {
-    $this->invocations[__FUNCTION__]= [$test];
+  public function testStarted(TestStart $start) {
+    $this->invocations[__FUNCTION__]= [$start];
   }
 
   /**
@@ -158,7 +152,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertInstanceOf(TestStart::class, $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestExpectationMet::class, $this->invocations['testSucceeded'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -172,7 +166,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertInstanceOf(TestStart::class, $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestAssertionFailed::class, $this->invocations['testFailed'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -186,7 +180,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertInstanceOf(TestStart::class, $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestError::class, $this->invocations['testError'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -200,7 +194,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertInstanceOf(TestStart::class, $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestWarning::class, $this->invocations['testWarning'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -215,7 +209,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertInstanceOf(TestStart::class, $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestPrerequisitesNotMet::class, $this->invocations['testSkipped'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);
@@ -229,7 +223,7 @@ class ListenerTest extends TestCase implements TestListener {
     $this->suite->addListener($this);
     $this->suite->runTest($case);
     $this->assertEquals($this->suite, $this->invocations['testRunStarted'][0]);
-    $this->assertEquals(new TestCaseInstance($case), $this->invocations['testStarted'][0]);
+    $this->assertInstanceOf(TestStart::class, $this->invocations['testStarted'][0]);
     $this->assertInstanceOf(TestNotRun::class, $this->invocations['testNotRun'][0]);
     $this->assertEquals($this->suite, $this->invocations['testRunFinished'][0]);
     $this->assertInstanceOf(TestResult::class, $this->invocations['testRunFinished'][1]);


### PR DESCRIPTION
See https://github.com/xp-framework/unittest/pull/37#issuecomment-537023414:

> Create a new interface unittest.Listener (without the Test prefix) with the new method. Clients can now > implement both, and based on type existance, pass the correct one

```diff
index b1802ef..92ec6af 100755
--- a/src/main/php/unittest/TestListener.class.php
+++ b/src/main/php/unittest/TestListener.class.php
@@ -4,6 +4,7 @@
  * To intercept certain events during a test run, add a listener to
  * the test suite before calling its run() or runTest() methods.
  *
+ * @deprecated Use Listener instead!
  * @test  xp://net.xp_framework.unittest.tests.ListenerTest
  * @see   xp://unittest.TestSuite#addListener
  */
@@ -12,35 +13,35 @@ interface TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param  unittest.TestCase $test
    */
-  public function testStarted(TestCase $case);
+  public function testStarted(TestCase $test);
 
```