### PR TITLE
Rewrite annotations to use map syntax instead of key/value pairs

### DIFF
--- a/src/test/php/unittest/tests/LimitTest.class.php
+++ b/src/test/php/unittest/tests/LimitTest.class.php
@@ -19,7 +19,7 @@ class LimitTest extends TestCase {
   #[@test]
   public function timeouts() {
     $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @limit(time= 0.010)] fixture' => function() {
+      '#[@test, @limit(["time" => 0.010])] fixture' => function() {
         usleep(20 * 1000);
       }
     ]));
@@ -29,7 +29,7 @@ class LimitTest extends TestCase {
   #[@test]
   public function noTimeout() {
     $r= $this->suite->runTest(newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @limit(time= 0.010)] fixture' => function() {
+      '#[@test, @limit(["time" => 0.010])] fixture' => function() {
         /* No timeout */
       }
     ]));

--- a/src/test/php/unittest/tests/RuntimeVersionTest.class.php
+++ b/src/test/php/unittest/tests/RuntimeVersionTest.class.php
@@ -124,7 +124,7 @@ class RuntimeVersionTest extends TestCase {
     $this->assertFalse((new RuntimeVersion('~1.2.3'))->verify($value));
   }
 
-  #[@test, @expect(class= 'unittest.PrerequisitesNotMetError', withMessage= '/Test not intended for this version/')]
+  #[@test, @expect(['class' => 'unittest.PrerequisitesNotMetError', 'withMessage' => '/Test not intended for this version/'])]
   public function beforeTest_throws_exception() {
     (new RuntimeVersion('1.0.0'))->beforeTest(new TestCaseInstance($this));
   }

--- a/src/test/php/unittest/tests/SpecialMethodsTest.class.php
+++ b/src/test/php/unittest/tests/SpecialMethodsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace unittest\tests;
 
+use lang\IllegalStateException;
 use unittest\TestCase;
 use unittest\TestSuite;
-use lang\IllegalStateException;
 
 /**
  * Test TestCase class special methods cannot be overwritten as test methods
@@ -49,12 +49,12 @@ class SpecialMethodsTest extends TestCase {
     }
   }
   
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot override/'])]
   public function setUpMethodMayNotBeATestInAddTestClass() {
     $this->suite->addTestClass(typeof($this->setUpCase()));
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot override/'])]
   public function setUpMethodMayNotBeATestInAddTest() {
     $this->suite->addTest($this->setUpCase());
   }
@@ -83,22 +83,22 @@ class SpecialMethodsTest extends TestCase {
     }');
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot override/'])]
   public function tearDownMethodMayNotBeATestInAddTestClass() {
     $this->suite->addTestClass(typeof($this->tearDownCase()));
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot override/'])]
   public function tearDownMethodMayNotBeATestInAddTest() {
     $this->suite->addTest($this->tearDownCase());
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot override/'])]
   public function getNameMethodMayNotBeATestInAddTestClass() {
     $this->suite->addTestClass(typeof($this->getNameCase()));
   }
 
-  #[@test, @expect(class= IllegalStateException::class, withMessage= '/Cannot override/')]
+  #[@test, @expect(['class' => IllegalStateException::class, 'withMessage' => '/Cannot override/'])]
   public function getNameMethodMayNotBeATestInAddTest() {
     $this->suite->addTest($this->getNameCase());
   }

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -518,7 +518,7 @@ class SuiteTest extends TestCase {
   #[@test]
   public function catchExpectedWithMessage() {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "Test")] fixture' => function() {
+      '#[@test, @expect(["class" => "lang.IllegalArgumentException", "withMessage" => "Test"])] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
     ]));
@@ -529,7 +529,7 @@ class SuiteTest extends TestCase {
   #[@test]
   public function catchExpectedWithMismatchingMessage() {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "Hello")] fixture' => function() {
+      '#[@test, @expect(["class" => "lang.IllegalArgumentException", "withMessage" => "Hello"])] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
     ]));
@@ -544,7 +544,7 @@ class SuiteTest extends TestCase {
   #[@test]
   public function catchExpectedWithPatternMessage() {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "/[tT]est/")] fixture' => function() {
+      '#[@test, @expect(["class" => "lang.IllegalArgumentException", "withMessage" => "/[tT]est/"])] fixture' => function() {
         throw new IllegalArgumentException('Test');
       }
     ]));
@@ -555,7 +555,7 @@ class SuiteTest extends TestCase {
   #[@test]
   public function catchExpectedWithEmptyMessage() {
     $this->suite->addTest(newinstance(TestCase::class, ['fixture'], [
-      '#[@test, @expect(class= "lang.IllegalArgumentException", withMessage= "")] fixture' => function() {
+      '#[@test, @expect(["class" => "lang.IllegalArgumentException", "withMessage" => ""])] fixture' => function() {
         throw new IllegalArgumentException('');
       }
     ]));

--- a/src/test/php/unittest/tests/UnittestRunnerTest.class.php
+++ b/src/test/php/unittest/tests/UnittestRunnerTest.class.php
@@ -295,7 +295,7 @@ class UnittestRunnerTest extends TestCase {
   public function withNamedLongListenerOption() {
     $class= ClassLoader::getDefault()->defineClass('unittest.tests.WithNamedLongListenerOptionTestFixture', 'xp.unittest.DefaultListener', [], '{
       public static $options= [];
-      #[@arg(name = "use")]
+      #[@arg(["name" => "use"])]
       public function setOption($value) { self::$options[__FUNCTION__]= $value; }
     }');
 
@@ -310,7 +310,7 @@ class UnittestRunnerTest extends TestCase {
   public function withNamedLongListenerOptionShort() {
     $class= ClassLoader::getDefault()->defineClass('unittest.tests.WithNamedLongListenerOptionShortTestFixture', 'xp.unittest.DefaultListener', [], '{
       public static $options= [];
-      #[@arg(name = "use")]
+      #[@arg(["name" => "use"])]
       public function setOption($value) { self::$options[__FUNCTION__]= $value; }
     }');
 
@@ -340,7 +340,7 @@ class UnittestRunnerTest extends TestCase {
   public function withNamedShortListenerOption() {
     $class= ClassLoader::getDefault()->defineClass('unittest.tests.WithNamedShortListenerOptionTestFixture', 'xp.unittest.DefaultListener', [], '{
       public static $options= [];
-      #[@arg(short = "O")]
+      #[@arg(["short" => "O"])]
       public function setOption($value) { self::$options[__FUNCTION__]= $value; }
     }');
 
@@ -355,7 +355,7 @@ class UnittestRunnerTest extends TestCase {
   public function withPositionalOptionListenerOption() {
     $class= ClassLoader::getDefault()->defineClass('unittest.tests.WithPositionalOptionTestFixture', 'xp.unittest.DefaultListener', [], '{
       public static $options= [];
-      #[@arg(position= 0)]
+      #[@arg(["position" => 0])]
       public function setOption($value) { self::$options[__FUNCTION__]= $value; }
     }');
 

--- a/src/test/php/unittest/tests/ValuesTest.class.php
+++ b/src/test/php/unittest/tests/ValuesTest.class.php
@@ -50,7 +50,7 @@ class ValuesTest extends TestCase {
     $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
-      #[@test, @values(map= ["a" => "b", "c" => "d"])]
+      #[@test, @values(["map" => ["a" => "b", "c" => "d"]])]
       public function fixture($key, $value) {
         $this->values[]= [$key, $value];
       }
@@ -86,7 +86,7 @@ class ValuesTest extends TestCase {
         return range($lo, $hi);
       }
 
-      #[@test, @values(source= "range", args= [1, 4])]
+      #[@test, @values(["source" => "range", "args" => [1, 4]])]
       public function fixture($value) {
         $this->values[]= $value;
       }
@@ -104,7 +104,7 @@ class ValuesTest extends TestCase {
         return range($lo, $hi);
       }
 
-      #[@test, @values(source= "range")]
+      #[@test, @values(["source" => "range"])]
       public function fixture($value) {
         $this->values[]= $value;
       }
@@ -146,7 +146,7 @@ class ValuesTest extends TestCase {
     $test= newinstance(TestCase::class, ['fixture'], '{
       public $values= [];
 
-      #[@test, @values(source= "unittest.tests.ValuesTest::range", args= [1, 10])]
+      #[@test, @values(["source" => "unittest.tests.ValuesTest::range", "args" => [1, 10]])]
       public function fixture($value) {
         $this->values[]= $value;
       }


### PR DESCRIPTION
Implements xp-framework/rfc#335