### PR TITLE
Implement Assert::throws()

### DIFF
--- a/src/main/php/unittest/Assert.class.php
+++ b/src/main/php/unittest/Assert.class.php
@@ -91,4 +91,27 @@ abstract class Assert {
       throw new AssertionFailedError(new ComparisonFailedMessage($error, $t->getName(), typeof($actual)->getName()));
     }
   }
+
+  /**
+   * Assert that a given exception is raised
+   *
+   * @param  string|lang.Type $type
+   * @param  callable $func
+   * @return void
+   */
+  public static function throws($type, $func) {
+    $t= $type instanceof Type ? $type : Type::forName($type);
+    try {
+      $func();
+    } catch (\Throwable $expected) {
+      if ($t->isInstance($expected)) return;
+
+      throw new AssertionFailedError(new ComparisonFailedMessage(
+        'instanceof',
+        $t->getName().': **',
+        nameof($expected).': '.$expected->getMessage()
+      ));
+    }
+    throw new AssertionFailedError('Expected '.$t->getName().', but no exception was raised');
+  }
 }

--- a/src/test/php/unittest/tests/AssertTest.class.php
+++ b/src/test/php/unittest/tests/AssertTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
 
+use lang\{IllegalAccessException, IllegalArgumentException, Throwable};
 use unittest\{Assert, AssertionFailedError};
 
 class AssertTest {
@@ -84,5 +85,33 @@ class AssertTest {
   #[@test, @expect(AssertionFailedError::class)]
   public function instanceof_raises_error_when_given_non_instance() {
     Assert::instance(Value::class, $this);
+  }
+
+  #[@test]
+  public function catch_expected() {
+    Assert::throws(IllegalAccessException::class, function() {
+      throw new IllegalAccessException('Test');
+    });
+  }
+
+  #[@test]
+  public function catch_subclass_of_expected() {
+    Assert::throws(Throwable::class, function() {
+      throw new IllegalAccessException('Test');
+    });
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function no_exception_thrown() {
+    Assert::throws(IllegalAccessException::class, function() {
+      // NOOP
+    });
+  }
+
+  #[@test, @expect(AssertionFailedError::class)]
+  public function different_exception_thrown() {
+    Assert::throws(IllegalAccessException::class, function() {
+      throw new IllegalArgumentException('Test');
+    });
   }
 }

--- a/src/test/php/unittest/tests/AssertionsTest.class.php
+++ b/src/test/php/unittest/tests/AssertionsTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace unittest\tests;
  
+use lang\XPClass;
 use unittest\{AssertionFailedError, TestCase};
 use util\Objects;
 
@@ -157,39 +158,39 @@ class AssertionsTest extends TestCase {
 
   #[@test]
   public function thisIsAnInstanceOfTestCaseClass() {
-    $this->assertInstanceOf(\lang\XPClass::forName('unittest.TestCase'), $this);
+    $this->assertInstanceOf(XPClass::forName('unittest.TestCase'), $this);
   }    
 
   #[@test]
   public function thisIsAnInstanceOfObject() {
-    $this->assertInstanceOf(\lang\Value::class, $this);
+    $this->assertInstanceOf('lang.Value', $this);
   }    
 
   #[@test]
   public function objectIsAnInstanceOfObject() {
-    $this->assertInstanceOf(\lang\Value::class, new Value(2));
+    $this->assertInstanceOf('lang.Value', new Value(2));
   }    
 
-  #[@test, @expect(
-  #  class= AssertionFailedError::class,
-  #  withMessage= 'expected ["lang.Value"] but was ["int"]'
-  #)]
+  #[@test, @expect([
+  #  'class'       => AssertionFailedError::class,
+  #  'withMessage' => 'expected ["lang.Value"] but was ["int"]'
+  #])]
   public function zeroIsNotAnInstanceOfValue() {
-    $this->assertInstanceOf(\lang\Value::class, 0);
+    $this->assertInstanceOf('lang.Value', 0);
   }    
 
-  #[@test, @expect(
-  #  class= AssertionFailedError::class,
-  #  withMessage= 'expected ["lang.Value"] but was ["void"]'
-  #)]
+  #[@test, @expect([
+  #  'class'       => AssertionFailedError::class,
+  #  'withMessage' => 'expected ["lang.Value"] but was ["void"]'
+  #])]
   public function nullIsNotAnInstanceOfValue() {
-    $this->assertInstanceOf(\lang\Value::class, null);
+    $this->assertInstanceOf('lang.Value', null);
   }    
 
-  #[@test, @expect(
-  #  class= AssertionFailedError::class,
-  #  withMessage= 'expected ["unittest.tests.Value"] but was ["unittest.tests.AssertionsTest"]'
-  #)]
+  #[@test, @expect([
+  #  'class'       => AssertionFailedError::class,
+  #  'withMessage' => 'expected ["unittest.tests.Value"] but was ["unittest.tests.AssertionsTest"]'
+  #])]
   public function thisIsNotAnInstanceOfValue() {
     $this->assertInstanceOf(Value::class, $this);
   }    


### PR DESCRIPTION
This pull request implements a new method `throws()` in the assertion DSL. With it, code along the lines of the following can be rewritten to a more concise form:

### Before

```php
use lang\IllegalArgumentException;

class FixtureTest {

  #[@test]
  public function raises_exception() {
    $fixture= ... // Code which could also raise IllegalArgumentExceptions
    try {
      $fixture->test(null);
      $this->fail('No exception raised', null, IllegalArgumentException::class);
    } catch (IllegalArgumentException $expected) {
       // OK
    }
  }
}
```

### After

```php
use lang\IllegalArgumentException;

class FixtureTest {

  #[@test]
  public function raises_exception() {
    $fixture= ... // Code which could also raise IllegalArgumentExceptions
    Assert::throws(IllegalArgumentException::class, function() use($fixture) {
      $fixture->test(null);
    });
  }
}
```