### PR TITLE
User preferences

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ Unittests change log
 
 ## ?.?.? / ????-??-??
 
+* Merged PR #44: Show source code location where test errors were
+  raised in verbose listener
+  (@thekid)
+
 ## 11.1.0 / 2020-09-20
 
 * Fixed issue #42: No constructor error for class::method - @thekid

--- a/src/main/php/xp/unittest/ColoredBarListener.class.php
+++ b/src/main/php/xp/unittest/ColoredBarListener.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
-use unittest\TestListener;
+use unittest\{Test, Listener};
 
 /**
  * Colorful verbose test listener
@@ -15,7 +15,7 @@ use unittest\TestListener;
  *   information out instantly)
  *
  */
-class ColoredBarListener implements TestListener {
+class ColoredBarListener implements Listener {
   const PROGRESS_WIDTH= 10;
 
   private $out= null;
@@ -39,10 +39,10 @@ class ColoredBarListener implements TestListener {
   /**
    * Write status of currently executing test case
    *
-   * @param   unittest.TestCase case
+   * @param   unittest.Test $test
    */
-  private function writeStatus(\unittest\TestCase $case= null) {
-    if (null !== $case) {
+  private function writeStatus(Test $test= null) {
+    if (null !== $test) {
       $this->cur++;
     }
 
@@ -50,7 +50,7 @@ class ColoredBarListener implements TestListener {
     $out= sprintf(" Running %-3d of %d [%-10s] %01dF %01dE %01dW %01dS %01dN",
       $this->cur,
       $this->sum,
-      str_repeat(".", $perc),
+      str_repeat('.', $perc),
       $this->stats['failed'],
       $this->stats['errored'],
       $this->stats['warned'],
@@ -64,7 +64,7 @@ class ColoredBarListener implements TestListener {
     );
 
     $this->recycleLine();
-    $this->writeColoredLine($out, $this->colorCodeFor($this->status, null === $case));
+    $this->writeColoredLine($out, $this->colorCodeFor($this->status, null === $test));
   }
 
   /**
@@ -123,10 +123,10 @@ class ColoredBarListener implements TestListener {
   /**
    * Called when a test case starts.
    *
-   * @param   unittest.TestCase failure
+   * @param   unittest.TestStart $start
    */
-  public function testStarted(\unittest\TestCase $case) {
-    $this->writeStatus($case);
+  public function testStarted(\unittest\TestStart $start) {
+    $this->writeStatus($start->test());
   }
 
   /**

--- a/src/main/php/xp/unittest/TestListeners.class.php
+++ b/src/main/php/xp/unittest/TestListeners.class.php
@@ -3,9 +3,7 @@
 use io\streams\OutputStreamWriter;
 use lang\Enum;
 
-/**
- * Listeners enumeration
- */
+/** Listeners enumeration */
 abstract class TestListeners extends Enum {
   public static $DEFAULT, $VERBOSE, $QUIET;
   
@@ -28,6 +26,16 @@ abstract class TestListeners extends Enum {
         return \lang\XPClass::forName("xp.unittest.QuietListener");
       }
     }');
+  }
+
+  /**
+   * Creates a listener from a given name
+   *
+   * @param  string $name
+   * @return self
+   */
+  public static function named($name) {
+    return Enum::valueOf(self::class, strtoupper($name));
   }
 
   /**

--- a/src/main/php/xp/unittest/TestListeners.class.php
+++ b/src/main/php/xp/unittest/TestListeners.class.php
@@ -5,10 +5,11 @@ use lang\Enum;
 
 /** Listeners enumeration */
 abstract class TestListeners extends Enum {
-  public static $DEFAULT, $VERBOSE, $QUIET, $BAR;
+  public static $COMPACT, $VERBOSE, $QUIET, $BAR;
+  public static $DEFAULT;
   
   static function __static() {
-    self::$DEFAULT= newinstance(__CLASS__, [0, 'DEFAULT'], '{
+    self::$COMPACT= newinstance(__CLASS__, [0, 'COMPACT'], '{
       static function __static() { }
       public function getImplementation() {
         return \lang\XPClass::forName("xp.unittest.DefaultListener");
@@ -32,6 +33,8 @@ abstract class TestListeners extends Enum {
         return \lang\XPClass::forName("xp.unittest.ColoredBarListener");
       }
     }');
+
+    self::$DEFAULT= self::$COMPACT;
   }
 
   /**

--- a/src/main/php/xp/unittest/TestListeners.class.php
+++ b/src/main/php/xp/unittest/TestListeners.class.php
@@ -5,7 +5,7 @@ use lang\Enum;
 
 /** Listeners enumeration */
 abstract class TestListeners extends Enum {
-  public static $DEFAULT, $VERBOSE, $QUIET;
+  public static $DEFAULT, $VERBOSE, $QUIET, $BAR;
   
   static function __static() {
     self::$DEFAULT= newinstance(__CLASS__, [0, 'DEFAULT'], '{
@@ -24,6 +24,12 @@ abstract class TestListeners extends Enum {
       static function __static() { }
       public function getImplementation() {
         return \lang\XPClass::forName("xp.unittest.QuietListener");
+      }
+    }');
+    self::$BAR= newinstance(__CLASS__, [3, 'BAR'], '{
+      static function __static() { }
+      public function getImplementation() {
+        return \lang\XPClass::forName("xp.unittest.ColoredBarListener");
       }
     }');
   }

--- a/src/main/php/xp/unittest/TestRunner.class.php
+++ b/src/main/php/xp/unittest/TestRunner.class.php
@@ -321,6 +321,8 @@ class TestRunner {
           $arguments[]= $this->arg($args, ++$i, 'a');
         } else if ('-s' === $args[$i]) {
           $stop= $this->arg($args, ++$i, 's');
+        } else if ('-v' === $args[$i]) {
+          $output= TestListeners::$VERBOSE;
         } else if ('--color' === substr($args[$i], 0, 7)) {
           $remainder= (string)substr($args[$i], 8);
           if (!array_key_exists($remainder, self::$colors)) {

--- a/src/main/php/xp/unittest/TestRunner.class.php
+++ b/src/main/php/xp/unittest/TestRunner.class.php
@@ -42,7 +42,7 @@ use xp\unittest\sources\{ClassFileSource, ClassSource, EvaluationSource, FolderS
  *   $ xp -watch . test src/test/php
  *   ```
  *
- * The `-q` option suppresses all output, `-o` *default|quiet|verbose|bar*
+ * The `-q` option suppresses all output, `-o` *compact|quiet|verbose|bar*
  * selects output. By default, all test methods are run. To interrupt this,
  * use `-s` *fail|ignore|skip*. Arguments to tests can be passed by supplying
  * one or more `-a` *{value}*.
@@ -51,7 +51,7 @@ use xp\unittest\sources\{ClassFileSource, ClassSource, EvaluationSource, FolderS
  * (~/.xp or $XDG_CONFIG_DIR/xp on Un*x, %APPDATA%\Xp on Windows), which
  * may contain the following configuration options and values:
  * `
- *   output=default|verbose|quiet|bar
+ *   output=compact|verbose|quiet|bar
  *   colors=on|off|auto
  *   stop=never|fail[,skip[,ignore]]
  * `
@@ -366,6 +366,7 @@ class TestRunner {
     if ($stop) {
       $events= 0;
       foreach (explode(',', $stop) as $event) {
+        $event= trim($event);
         if (isset(self::$stop[$event])) {
           $events |= self::$stop[$event];
         } else {

--- a/src/main/php/xp/unittest/XTermTitleListener.class.php
+++ b/src/main/php/xp/unittest/XTermTitleListener.class.php
@@ -1,7 +1,7 @@
 <?php namespace xp\unittest;
 
 use io\streams\OutputStreamWriter;
-use unittest\{Listener, TestStart, TestSuite};
+use unittest\{Listener, Test, TestStart, TestSuite};
 
 /**
  * XTerm Title listener
@@ -31,10 +31,9 @@ class XTermTitleListener implements Listener {
   private function writeStatus(Test $test) {
     $this->cur++;
 
-    $perc= floor($this->cur / $this->sum * self::PROGRESS_WIDTH);
-
+    $percent= (int)($this->cur / $this->sum * self::PROGRESS_WIDTH);
     $this->out->writef("\033]2;Running: [%s%s] %s()\007",
-      str_repeat('*', $perc), str_repeat('-', self::PROGRESS_WIDTH- $perc),
+      str_repeat('*', $percent), str_repeat('-', self::PROGRESS_WIDTH - $percent),
       $test->getName(true)
     );
   }
@@ -45,7 +44,7 @@ class XTermTitleListener implements Listener {
    * @param  unittest.TestStart $start
    */
   public function testStarted(TestStart $start) {
-    $this->writeStatus($test);
+    $this->writeStatus($start->test());
   }
 
   /**


### PR DESCRIPTION
Add support for user preferences via test.ini in environment config dir

* ~/.xp/test.ini or $XDG_CONFIG_HOME/xp/test.ini on Un*x
* %APPDATA%\Xp\test.ini on Windows

```ini
; One of compact, bar, verbose or quiet.
output=compact

; Use terminal colors, one of on, off, auto.
colors=auto

; Stop test run, either never or a comma-separated list of one or more of fail, skip, ignore.
stop=never
```

The help function shows these possible configuration options