### PR TITLE
Use unicode characters to improve test status bar

### DIFF
--- a/src/main/php/xp/unittest/ColoredBarListener.class.php
+++ b/src/main/php/xp/unittest/ColoredBarListener.class.php
@@ -53,7 +53,7 @@ class ColoredBarListener implements Listener {
   
     // Create status bar
     $done= floor($this->cur / $this->sum * self::PROGRESS_WIDTH);
-    $status= sprintf('Running %-3d of %d ▐%s▌ %01dF %01dE %01dW %01dS %01dN',
+    $status= sprintf('Running %-3d of %d ▐%s▌ %01d 📛▕ %01d ❌▕ %01d ⚡▕ %01d ⏩▕ %01d ⌛',
       $this->cur,
       $this->sum,
       str_repeat('█', $done).str_repeat(' ', self::PROGRESS_WIDTH - $done),
@@ -122,8 +122,9 @@ class ColoredBarListener implements Listener {
    * @param   unittest.TestWarning warning
    */
   public function testWarning(\unittest\TestWarning $warning) {
-    $this->writeFailure($warning);
+    $this->status= false;
     $this->stats['warned']++;
+    $this->writeFailure($warning);
   }
 
   /**

--- a/src/main/php/xp/unittest/ColoredBarListener.class.php
+++ b/src/main/php/xp/unittest/ColoredBarListener.class.php
@@ -66,7 +66,7 @@ class ColoredBarListener implements Listener {
 
     // Format output so it's 72 characters wide (8 for status, 2 spaces padding)
     $this->out->writef(
-      "\r\033[%sm  %s%s▌ %s  \033[0m",
+      "\r\033[%sm  %s%s❯ %s  \033[0m",
       $color,
       $status,
       str_repeat(' ', 60 - iconv_strlen($status, 'utf-8')),

--- a/src/main/php/xp/unittest/ColoredBarListener.class.php
+++ b/src/main/php/xp/unittest/ColoredBarListener.class.php
@@ -41,17 +41,19 @@ class ColoredBarListener implements Listener {
    * @return void
    */
   private function writeStatus(Test $test= null) {
-    if (null === $test) {
-      $this->cur= $this->sum;
-      $done= self::PROGRESS_WIDTH;
-      $color= $this->status ? self::CODE_GREEN : self::CODE_RED;
-    } else {
+    if ($test) {
       $this->cur++;
-      $done= floor($this->cur / $this->sum * self::PROGRESS_WIDTH);
       $color= self::CODE_BLUE;
+    } else if ($this->status) {
+      $this->cur= $this->sum;
+      $color= self::CODE_GREEN;
+    } else {
+      $color= self::CODE_RED;
     }
   
-    $out= sprintf('Running %-3d of %d ▐%s▌ %01dF %01dE %01dW %01dS %01dN',
+    // Create status bar
+    $done= floor($this->cur / $this->sum * self::PROGRESS_WIDTH);
+    $status= sprintf('Running %-3d of %d ▐%s▌ %01dF %01dE %01dW %01dS %01dN',
       $this->cur,
       $this->sum,
       str_repeat('█', $done).str_repeat(' ', self::PROGRESS_WIDTH - $done),
@@ -66,8 +68,8 @@ class ColoredBarListener implements Listener {
     $this->out->writef(
       "\r\033[%sm  %s%s▌ %s  \033[0m",
       $color,
-      $out,
-      str_repeat(' ', 60 - iconv_strlen($out, 'utf-8')),
+      $status,
+      str_repeat(' ', 60 - iconv_strlen($status, 'utf-8')),
       $this->status ? 'PASSING' : 'FAILURE!'
     );
   }
@@ -81,17 +83,6 @@ class ColoredBarListener implements Listener {
     $this->out->write("\r");
     $this->out->writeLine($result);
     $this->out->writeLine();
-  }
-
-  /**
-   * Write colored line
-   *
-   * @param   string line
-   * @param   string code
-   */
-  private function writeColoredLine($line, $code) {
-    $this->len= strlen($line);
-    $this->out->write($code.$line.self::$CODE_RESET);
   }
 
   /**


### PR DESCRIPTION
Before:

![Before](https://user-images.githubusercontent.com/696742/120941905-a754c500-c725-11eb-9599-b9b59a79fe81.png)

After:

![After](https://user-images.githubusercontent.com/696742/120942707-efc2b180-c72a-11eb-8b43-b45560387bac.png)

*See https://github.com/sindresorhus/cli-spinners/blob/HEAD/spinners.json for CLI spinners inspiration*

/cc @kiesel  who was the original author of this test status bar.