### PR TITLE
Use PrerequisitesFailedError for unexpected exceptions

### DIFF
--- a/src/main/php/unittest/TestGroup.class.php
+++ b/src/main/php/unittest/TestGroup.class.php
@@ -76,7 +76,7 @@ abstract class TestGroup {
           throw $cause;
         } else {
           $name= substr(strstr($e->getMessage(), '::'), 2);
-          throw new PrerequisitesNotMetError('Exception in beforeClass method '.$name, $cause);
+          throw new PrerequisitesFailedError($cause->getMessage(), $cause, [$name]);
         }
       }
       $it->next();

--- a/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
+++ b/src/test/php/unittest/tests/BeforeAndAfterClassTest.class.php
@@ -43,7 +43,7 @@ abstract class BeforeAndAfterClassTest extends TestCase {
   }
 
   #[Test]
-  public function exceptionInBeforeClassSkipsTest() {
+  public function exceptionInBeforeClassFailsTest() {
     $t= newinstance(TestCase::class, ['fixture'], '{
 
       #[BeforeClass]
@@ -57,9 +57,9 @@ abstract class BeforeAndAfterClassTest extends TestCase {
       }
     }');
     $r= $this->suite->runTest($t)->outComeOf($t);
-    $this->assertInstanceOf(TestSkipped::class, $r);
-    $this->assertInstanceOf(PrerequisitesNotMetError::class, $r->reason);
-    $this->assertEquals('Exception in beforeClass method prepareTestData', $r->reason->getMessage());
+    $this->assertInstanceOf(TestFailure::class, $r);
+    $this->assertInstanceOf(PrerequisitesFailedError::class, $r->reason);
+    $this->assertEquals('Test data not available', $r->reason->getMessage());
   }
 
   #[Test]

--- a/src/test/php/unittest/tests/SuiteTest.class.php
+++ b/src/test/php/unittest/tests/SuiteTest.class.php
@@ -361,7 +361,7 @@ class SuiteTest extends TestCase {
     $t= newinstance(TestCase::class, ['irrelevant'], '{
       #[BeforeClass]
       public static function raise() {
-        throw new \lang\IllegalStateException("Skip");
+        throw new \unittest\PrerequisitesNotMetError("Skip");
       }
       
       #[Test]
@@ -374,7 +374,7 @@ class SuiteTest extends TestCase {
     $this->assertEquals(1, $r->skipCount(), 'skipCount');
     $this->assertInstanceOf(TestPrerequisitesNotMet::class, $r->outcomeOf($t));
     $this->assertInstanceOf(PrerequisitesNotMetError::class, $r->outcomeOf($t)->reason);
-    $this->assertEquals('Exception in beforeClass method raise', $r->outcomeOf($t)->reason->getMessage());
+    $this->assertEquals('Skip', $r->outcomeOf($t)->reason->getMessage());
   }    
 
   #[Test]


### PR DESCRIPTION
...while PrerequisitesNotMetError is for expected prerequisite exceptions. 

![image](https://user-images.githubusercontent.com/696742/208517590-ba083a63-55e1-469d-9d26-e25766eae660.png)

Implements #48
